### PR TITLE
fix: gallery exclusion bug + aggressive_cleanup on pipeline rebuild

### DIFF
--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -2848,6 +2848,7 @@ def list_outputs(include_hidden: bool = False) -> list[dict]:
     #      apart from real outputs.
     in_flight_paths: set[str] = set()
     failed_paths: set[str] = set()
+    succeeded_paths: set[str] = set()
     with LOCK:
         hidden_snap = set(HIDDEN_PATHS)
         cur = STATE.get("current")
@@ -2857,11 +2858,21 @@ def list_outputs(include_hidden: bool = False) -> list[dict]:
                 if v:
                     in_flight_paths.add(str(v))
         for h in (STATE.get("history") or []):
-            if (h.get("status") or "") in ("failed", "cancelled", "error"):
+            status = (h.get("status") or "")
+            if status in ("failed", "cancelled", "error"):
                 for k in ("raw_path", "output_path", "native_path", "upscaled_path"):
                     v = h.get(k)
                     if v:
                         failed_paths.add(str(v))
+            elif status == "done":
+                for k in ("raw_path", "output_path", "native_path", "upscaled_path"):
+                    v = h.get(k)
+                    if v:
+                        succeeded_paths.add(str(v))
+    # A path that appears in both a failed and a done entry was successfully
+    # re-rendered after a crash (e.g. cold-start Metal failure + auto-retry).
+    # The successful render wins — remove it from the exclusion set.
+    failed_paths -= succeeded_paths
     inflight_mtime_cutoff = time.time() - 2.0
     out = []
     for p in files:

--- a/mlx_warm_helper.py
+++ b/mlx_warm_helper.py
@@ -556,6 +556,10 @@ def get_pipe(kind: str, loras: list[dict] | None = None,
     global _t2v_pipe, _i2v_pipe, _extend_pipe
     global _t2v_lora_key, _i2v_lora_key, _extend_lora_key
     global _extend_model_dir
+    try:
+        from ltx_core_mlx.utils.memory import aggressive_cleanup as _ac
+    except Exception:
+        _ac = lambda: None
     # Upstream refactor 2026-05-09 (commits d6cc3d1, 493aec2) renamed +
     # removed several pipeline classes. Past intermediate commits had a
     # mix of old + new names. Three import strategies in priority order:
@@ -598,6 +602,7 @@ def get_pipe(kind: str, loras: list[dict] | None = None,
                     emit({"event": "log",
                           "line": f"LoRA set changed; reloading I2V pipeline."})
                     _i2v_pipe = None
+                    _ac()
                 emit({"event": "log",
                       "line": "Loading I2V pipeline (first job is the slow one)..."})
                 pipe = ImageToVideoPipeline(
@@ -617,6 +622,7 @@ def get_pipe(kind: str, loras: list[dict] | None = None,
                     emit({"event": "log",
                           "line": f"{why}; reloading Extend pipeline."})
                     _extend_pipe = None
+                    _ac()
                 emit({"event": "log",
                       "line": f"Loading Extend pipeline (heavier — uses dev transformer at {ext_dir})..."})
                 pipe = ExtendPipeline(
@@ -633,6 +639,7 @@ def get_pipe(kind: str, loras: list[dict] | None = None,
                 emit({"event": "log",
                       "line": f"LoRA set changed; reloading T2V pipeline."})
                 _t2v_pipe = None
+                _ac()
             emit({"event": "log",
                   "line": "Loading T2V pipeline (first job is the slow one)..."})
             pipe = TextToVideoPipeline(
@@ -681,6 +688,10 @@ def get_hq_pipe(model_dir: str, loras: list[dict] | None = None):
 
     fp = _lora_fingerprint(loras)
 
+    try:
+        from ltx_core_mlx.utils.memory import aggressive_cleanup as _ac
+    except Exception:
+        _ac = lambda: None
     with _pipe_lock:
         release_pipelines(keep_kind="hq")
         if (_hq_pipe is None
@@ -690,6 +701,7 @@ def get_hq_pipe(model_dir: str, loras: list[dict] | None = None):
                 why = "LoRA set changed" if _hq_lora_key != fp else "model_dir changed"
                 emit({"event": "log", "line": f"{why}; reloading HQ pipeline."})
                 _hq_pipe = None
+                _ac()
             emit({"event": "log", "line": f"Loading HQ pipeline (Q8 dev model — {model_dir})..."})
             _hq_pipe = TwoStageHQPipeline(
                 model_dir=model_dir, gemma_model_id=GEMMA_PATH, low_memory=LOW_MEMORY,


### PR DESCRIPTION
*Note: I'm not a developer. These fixes were found and written by Claude Code while diagnosing issues on my machine. I'm sharing them back in case they're useful. Claude Code is also writing this message on my behalf.*

---

## Background

I've been using Phosphene on an M2 Max 64 GB Mac and hit a couple of issues while investigating crashes (separately reported in issue #3 and in a now-merged PR to the ltx-2-mlx engine). While working through those I noticed these two smaller bugs in the panel and helper.

## Fix 1 — Gallery hides successful re-renders after a crash

**Symptom:** After a render fails (e.g. a Metal cold-start crash), the job records its output path with status `"failed"`. If the same job is retried and succeeds, the new `"done"` history entry shares the same output path. `list_outputs()` was adding all failed-job paths to the exclusion set without checking whether a later successful render had claimed that path — so the successful video never appeared in the gallery.

**Fix (`mlx_ltx_panel.py`):** Collect `succeeded_paths` from `"done"` history entries in the same loop and subtract from `failed_paths` before the exclusion check. A path present in both sets belongs to a successful re-render and should not be hidden.

## Fix 2 — Missing `aggressive_cleanup()` after nulling a stale pipeline

**Symptom:** When the LoRA set changes between jobs, `get_pipe()` and `get_hq_pipe()` null the stale pipeline reference before rebuilding. Without an explicit `aggressive_cleanup()` at that point, the old pipeline's Metal buffers and MLX arrays remain live until the Python GC decides to collect them — which can coincide with the new pipeline's weight load and push total Metal memory over the allocator limit.

**Fix (`mlx_warm_helper.py`):** Call `aggressive_cleanup()` immediately after nulling the stale reference in all four pipeline-rebuild paths (i2v, extend, t2v, hq).

---

Both fixes are self-contained and don't touch any codepath that works correctly today. Happy to adjust anything that doesn't fit the project style.