### PR TITLE
fix(worker): retry cold-start Metal crash up to 3 times with increasing delays

### DIFF
--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -6710,27 +6710,48 @@ def worker_loop() -> None:
             else:
                 elapsed = time.time() - (job.get("started_ts") or time.time())
                 if _is_metal_warmup_crash(exc, elapsed):
-                    # Cold-start crash: macOS needs ~20 s to fully reclaim the
-                    # previous helper's Metal/GPU memory after a Stop/Start
-                    # cycle. Retrying immediately hits transient Metal
-                    # allocation failures while reclamation is in progress.
-                    push(
-                        "Cold-start crash — waiting 45 s for macOS to reclaim "
-                        "Metal memory from the previous helper, then auto-retrying..."
-                    )
-                    time.sleep(45)
-                    job.pop("error", None)
-                    job["status"] = "running"
-                    job["started_at"] = iso_now()
-                    job["started_ts"] = time.time()
-                    STATE["log"] = []
-                    try:
-                        run_job_inner(job)
-                        job["status"] = "done"
-                    except Exception as retry_exc:
-                        job["status"] = "failed"
-                        job["error"] = str(retry_exc)
-                        push(f"ERROR (retry also failed): {retry_exc}")
+                    # Cold-start crash: after a Stop/Start cycle macOS needs
+                    # time to reclaim the previous helper's Metal/GPU heap
+                    # (~10–15 GB on 64 GB Macs). A single 45 s wait proved
+                    # insufficient — on M2 Max 64 GB reclamation extended past
+                    # that window and the retry crashed at the same ~7 s mark
+                    # (confirmed via DiagnosticReports timestamps). Retry up to
+                    # 3 times with increasing delays; stop early if the retry
+                    # error is no longer a warmup crash (different root cause).
+                    _warmup_delays = [45, 60, 90]
+                    for _attempt, _delay in enumerate(_warmup_delays, 1):
+                        push(
+                            f"Cold-start Metal crash — waiting {_delay} s for macOS "
+                            f"to reclaim GPU memory "
+                            f"(retry {_attempt}/{len(_warmup_delays)})..."
+                        )
+                        time.sleep(_delay)
+                        if job.get("cancel_requested"):
+                            job["status"] = "cancelled"
+                            push("Job cancelled.")
+                            break
+                        job.pop("error", None)
+                        job["status"] = "running"
+                        job["started_at"] = iso_now()
+                        job["started_ts"] = time.time()
+                        STATE["log"] = []
+                        try:
+                            run_job_inner(job)
+                            job["status"] = "done"
+                            break
+                        except Exception as retry_exc:
+                            _retry_elapsed = time.time() - job["started_ts"]
+                            if (_attempt == len(_warmup_delays)
+                                    or not _is_metal_warmup_crash(retry_exc, _retry_elapsed)):
+                                if job.get("cancel_requested"):
+                                    job["status"] = "cancelled"
+                                    push("Job cancelled.")
+                                else:
+                                    job["status"] = "failed"
+                                    job["error"] = str(retry_exc)
+                                    push(f"ERROR (retry {_attempt} failed): {retry_exc}")
+                                break
+                            push(f"Retry {_attempt} also crashed — will try again.")
                 else:
                     job["status"] = "failed"
                     job["error"] = str(exc)

--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -6667,7 +6667,11 @@ def _is_metal_warmup_crash(exc: Exception, elapsed_sec: float) -> bool:
     __cxa_throw → terminate → abort. Confirmed via crash reports: the crash
     path is check_error → abort (NOT the JIT path createComputeProgramVariant
     → abort). The Metal shader cache is empty — cache-flushing is irrelevant.
-    Waiting 20 s gives macOS time to complete memory reclamation before retry.
+    Waiting 45 s gives macOS time to complete memory reclamation before retry.
+    20 s proved insufficient on M2 Max 64 GB: the retry crashed at ~7 s,
+    27 s after the first crash (confirmed via DiagnosticReports timestamps).
+    The heap reclamation window is proportional to heap size; at ~10–15 GB
+    it extends past 20 s on this tier.
 
     Detection criteria: the helper died within 20 seconds AND the error
     message names SIGABRT or an unexplained pipe close (both map to the same
@@ -6711,10 +6715,10 @@ def worker_loop() -> None:
                     # cycle. Retrying immediately hits transient Metal
                     # allocation failures while reclamation is in progress.
                     push(
-                        "Cold-start crash — waiting 20 s for macOS to reclaim "
+                        "Cold-start crash — waiting 45 s for macOS to reclaim "
                         "Metal memory from the previous helper, then auto-retrying..."
                     )
-                    time.sleep(20)
+                    time.sleep(45)
                     job.pop("error", None)
                     job["status"] = "running"
                     job["started_at"] = iso_now()

--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -6658,6 +6658,27 @@ def run_job_inner(job: dict) -> None:
 
 # ---- worker thread -----------------------------------------------------------
 
+def _is_metal_warmup_crash(exc: Exception, elapsed_sec: float) -> bool:
+    """True when the failure looks like a cold-start Metal memory crash.
+
+    After a helper Stop/Start cycle, the previous helper process's Metal/GPU
+    memory (~10 GB) is being reclaimed by macOS. A new helper spawned during
+    reclamation hits transient Metal allocation failures → check_error →
+    __cxa_throw → terminate → abort. Confirmed via crash reports: the crash
+    path is check_error → abort (NOT the JIT path createComputeProgramVariant
+    → abort). The Metal shader cache is empty — cache-flushing is irrelevant.
+    Waiting 20 s gives macOS time to complete memory reclamation before retry.
+
+    Detection criteria: the helper died within 20 seconds AND the error
+    message names SIGABRT or an unexplained pipe close (both map to the same
+    underlying abort path).
+    """
+    if elapsed_sec > 20:
+        return False
+    msg = str(exc).lower()
+    return "sigabrt" in msg or "helper pipe closed" in msg
+
+
 def worker_loop() -> None:
     while True:
         with QUEUE_COND:
@@ -6683,9 +6704,33 @@ def worker_loop() -> None:
                 job["status"] = "cancelled"
                 push("Job cancelled.")
             else:
-                job["status"] = "failed"
-                job["error"] = str(exc)
-                push(f"ERROR: {exc}")
+                elapsed = time.time() - (job.get("started_ts") or time.time())
+                if _is_metal_warmup_crash(exc, elapsed):
+                    # Cold-start crash: macOS needs ~20 s to fully reclaim the
+                    # previous helper's Metal/GPU memory after a Stop/Start
+                    # cycle. Retrying immediately hits transient Metal
+                    # allocation failures while reclamation is in progress.
+                    push(
+                        "Cold-start crash — waiting 20 s for macOS to reclaim "
+                        "Metal memory from the previous helper, then auto-retrying..."
+                    )
+                    time.sleep(20)
+                    job.pop("error", None)
+                    job["status"] = "running"
+                    job["started_at"] = iso_now()
+                    job["started_ts"] = time.time()
+                    STATE["log"] = []
+                    try:
+                        run_job_inner(job)
+                        job["status"] = "done"
+                    except Exception as retry_exc:
+                        job["status"] = "failed"
+                        job["error"] = str(retry_exc)
+                        push(f"ERROR (retry also failed): {retry_exc}")
+                else:
+                    job["status"] = "failed"
+                    job["error"] = str(exc)
+                    push(f"ERROR: {exc}")
         finally:
             job["finished_at"] = iso_now()
             if job.get("started_ts"):


### PR DESCRIPTION
## Problem

The existing single 45-second retry after a cold-start Metal crash proved insufficient on M2 Max 64 GB. After a Pinokio Stop/Start cycle, Metal heap reclamation took ~99 seconds on this machine — the retry fired at ~52 seconds, still within the unreclaimed window, and crashed again. The user was left seeing two failure cards requiring manual retries.

## Evidence

DiagnosticReports timestamps `python3.11-2026-05-17-202645.ips` and `python3.11-2026-05-17-202823.ips` confirm two consecutive SIGABRT crashes at the same ~7s mark. Third manual attempt (at ~99s from first crash) succeeded. The 45s retry introduced in 9da93c4 / 913aeca was a good approach but the delay wasn't sufficient for this hardware.

## Fix

Replace the single retry with a loop of up to 3 attempts at [45, 60, 90] second delays. The second retry fires at ~112 seconds from the original crash — comfortably past the observed 99-second recovery window. The loop stops early if the retry error changes to a non-warmup root cause. A `cancel_requested` check after each sleep ensures the Stop button works correctly during the wait window (previously the job would wake and retry anyway).

User-visible change: instead of red failure cards requiring manual retries, the job stays running with log messages showing which retry attempt is in progress.

*Code reviewed by Gemini 2.5 Pro prior to submission — the cancellation-during-sleep edge case was identified during that review.*

---
*Note: I'm not a developer. I'm a user who encountered these crashes and project-managed this fix using Claude Code and Gemini to do the actual analysis and implementation. I've tested it on my own machine and it resolved the issue for me. Happy for you to review, modify, or reject as you see fit.*