### PR TITLE
fix: download spatial upscaler for Q4 model (fixes #23)

### DIFF
--- a/required_files.json
+++ b/required_files.json
@@ -11,14 +11,15 @@
       "blurb": "Required. Drives Quick / Balanced / Standard renders.",
       "repo_id": "dgrauet/ltx-2.3-mlx-q4",
       "local_dir": "mlx_models/ltx-2.3-mlx-q4",
-      "size_gb": 20,
+      "size_gb": 21,
       "files": [
         "transformer-distilled.safetensors",
         "connector.safetensors",
         "vae_decoder.safetensors",
         "vae_encoder.safetensors",
         "audio_vae.safetensors",
-        "vocoder.safetensors"
+        "vocoder.safetensors",
+        "spatial_upscaler_x2_v1_1.safetensors"
       ],
       "download_include": [
         "*.json",
@@ -27,7 +28,8 @@
         "vae_decoder.safetensors",
         "vae_encoder.safetensors",
         "audio_vae.safetensors",
-        "vocoder.safetensors"
+        "vocoder.safetensors",
+        "spatial_upscaler_x2_v1_1.safetensors"
       ]
     },
     {


### PR DESCRIPTION
Fixes #23.

## Root cause

The mosaic/rainbow-grid is **not** an MLX Q4 kernel bug (the `mlx_q4_check.py` runs in the thread came back clean for everyone). It's a **missing model file**.

Every Q4 render path — Quick / Balanced / Standard — is a **two-stage** pipeline: stage 1 denoises at half resolution, then a **2× neural latent upscaler** runs, then stage 2 refines at full resolution. The upscaler is a separate weights file, `spatial_upscaler_x2_v1_1.safetensors`.

`required_files.json` lists that file under the **Q8** repo entry but **not** under **Q4**:

| | in Q4 `files`/`download_include`? |
|---|---|
| `spatial_upscaler_x2_v1_1.safetensors` | ❌ missing |

So a Q4 install never downloads it. In `ltx-pipelines-mlx` 0.14.8, `_load_upsampler` constructs a `LatentUpsampler` and only calls `load_weights` *if the file exists* — when it's absent it silently keeps a **randomly-initialised** upsampler. Stage 2 then upscales the latent through an untrained Conv3d + pixel-shuffle, which decodes into a periodic grid. The job completes with no error, on all prompts and quality settings.

This explains every data point in #23:
- **Q4 → mosaic** (no upscaler)
- **Q8 T2V → clean** (Q8 entry ships the upscaler)
- integrity check passes (the upscaler wasn't in the verified `files` list, so its absence was invisible)

## Fix

Add `spatial_upscaler_x2_v1_1.safetensors` to the Q4 entry's `files` and `download_include` in `required_files.json` (the single source of truth read by `install.js`, `pinokio.js`, and the panel's verify/repair). The file exists in `dgrauet/ltx-2.3-mlx-q4` (variant-independent bf16, ~1 GB); the `*.json` include already pulled its `_config.json`, so only the `.safetensors` was missing. Bumped `size_gb` 20 → 21.

Effect:
- **Fresh Q4 installs** download it automatically.
- **Existing installs**: `/models/verify` now flags it missing and `/models/repair` fetches it (~1 GB, resumable) — no full re-download.

## Verification

On an affected M2 Pro 32 GB / Q4 install, fetching the file into the Q4 model dir and re-running the same seed (distilled two-stage) turns the full-frame tessellation into a clean, coherent frame. No other change.

## Related

Upstream `ltx-pipelines-mlx` now raises a clear `FileNotFoundError` (naming the file + the `hf download` command) instead of silently degrading when the upscaler is absent: dgrauet/ltx-2-mlx#42. Once that pin lands, a missing upscaler fails loud rather than producing a mosaic.

> Note: the separate Q8-only image-generation (Qwen-Edit ~34 GB) limitation mentioned at the end of #23 is unrelated to this fix and out of scope here.