### PR TITLE
A2V distilled pipeline — Q4 audio-to-video, no ltx-2-mlx modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+## About this fork
+
+This fork adds A2V Distilled Pipeline (a2vid_distilled.py) in phosphene root for
+Q4-distilled audio-to-video generation. No ltx-2-mlx modifications
+required — imports from stock ltx-pipelines-mlx package.
+
+Key differences from the standard A2V path:
+- a2vid_distilled.py lives in phosphene root (not inside ltx-2-mlx)
+- mlx_warm_helper.py imports from the local a2vid_distilled module
+- Distilled path (generate_a2v_distilled) passes audio_conditioning_scale
+  (built into a2vid_distilled.py)
+- Non-distilled path (generate_a2v) omits audio_conditioning_scale
+  (upstream A2VidPipelineTwoStage does not accept it)
+- patch_ltx_codec.py is unchanged (codec patch only)
+
+
+
 <p align="center">
   <img src="assets/phosphene_banner.png" alt="Phosphene" width="100%">
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## About this fork
 
-This fork adds A2V Distilled Pipeline (a2vid_distilled.py) in phosphene root for
+This fork adds audio-to-video mode for low memory pipeline.
+
+Adds A2V Distilled Pipeline (a2vid_distilled.py) in phosphene root for
 Q4-distilled audio-to-video generation. No ltx-2-mlx modifications
 required — imports from stock ltx-pipelines-mlx package.
 

--- a/a2vid_distilled.py
+++ b/a2vid_distilled.py
@@ -1,0 +1,371 @@
+"""A2V Distilled Pipeline — audio-to-video with the distilled model.
+
+Mirrors the upstream ``DistilledPipeline`` approach: two-stage generation
+(half-res → upscale → full-res refine) with the distilled transformer
+and no CFG guidance. Handles audio conditioning from an input audio file.
+
+Requires only the distilled checkpoint (``transformer-distilled.safetensors``
+or ``transformer.safetensors``) — no dev model needed. Q4 compatible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+import mlx.core as mx
+
+from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
+from ltx_core_mlx.conditioning.types.latent_cond import LatentState
+from ltx_core_mlx.model.audio_vae import encode_audio
+from ltx_core_mlx.model.transformer.model import X0Model
+from ltx_core_mlx.utils.audio import load_audio
+from ltx_core_mlx.utils.memory import aggressive_cleanup
+from ltx_core_mlx.utils.positions import (
+    compute_audio_positions,
+    compute_audio_token_count,
+    compute_video_positions,
+)
+
+from ltx_pipelines_mlx.a2vid_two_stage import A2VidPipelineTwoStage
+from ltx_pipelines_mlx.scheduler import DISTILLED_SIGMAS, STAGE_2_SIGMAS
+from ltx_pipelines_mlx.utils.helpers import create_noised_state
+from ltx_pipelines_mlx.utils.progress import phase
+from ltx_pipelines_mlx.utils.samplers import denoise_loop
+
+_materialize = getattr(mx, "eval")
+
+
+class A2VidDistilledPipeline(A2VidPipelineTwoStage):
+    """Audio-to-video two-stage pipeline using the distilled model.
+
+    Uses the distilled transformer directly — no dev model, no CFG,
+    no LoRA fusion. Two-stage: half-res distilled -> upscale -> full-res
+    refine. Q4 compatible.
+
+    Args:
+        model_dir: Path to model weights or HuggingFace repo ID. Must
+            contain the distilled checkpoint (``transformer.safetensors``
+            or ``transformer-distilled.safetensors``).
+        gemma_model_id: Gemma model for text encoding.
+        low_memory: Aggressive memory management.
+        low_ram_streaming: Stream transformer blocks from disk.
+    """
+
+    def load(self) -> None:
+        """Load distilled DiT + upsampler (skip VAE encoder, skip decoders).
+
+        VAE encoder is loaded on demand by ``image_conditioner`` callbacks
+        during I2V conditioning and upscale steps — pre-loading it here
+        would waste ~800 MB peak memory for no benefit.
+        """
+        if self._loaded:
+            return
+
+        if self.dit is None:
+            transformer_path = self.model_dir / "transformer.safetensors"
+            if not transformer_path.exists():
+                transformer_path = self.model_dir / "transformer-distilled.safetensors"
+            self.dit = self._load_transformer_with_optional_streaming(transformer_path)
+
+        if self.upsampler is None:
+            self._load_upsampler()
+        self._loaded = True
+
+    def generate_and_save(
+        self,
+        prompt: str,
+        output_path: str,
+        audio_path: str | Path | None = None,
+        height: int = 480,
+        width: int = 704,
+        num_frames: int = 97,
+        *,
+        frame_rate: float,
+        seed: int = 42,
+        stage1_steps: int | None = None,
+        stage2_steps: int | None = None,
+        image: str | None = None,
+        images=None,
+        audio_start_time: float = 0.0,
+        audio_max_duration: float | None = None,
+        audio_conditioning_scale: float = 1.0,
+    ) -> str:
+        """Generate audio-to-video using the distilled pipeline.
+
+        Two-stage: half-res distilled -> upscale -> full-res refine.
+        Audio conditioning from the input file (frozen in stage 1,
+        denoised in stage 2). Original audio muxed into output for
+        maximum fidelity.
+
+        Args:
+            prompt: Text prompt.
+            output_path: Path to output video file.
+            audio_path: Path to input audio file (required).
+            height: Video height.
+            width: Video width.
+            num_frames: Number of frames.
+            frame_rate: Frame rate.
+            seed: Random seed.
+            stage1_steps: Stage 1 steps (default: full DISTILLED_SIGMAS = 8).
+            stage2_steps: Stage 2 steps (default: full STAGE_2_SIGMAS = 3).
+            image: Optional reference image for I2V conditioning (first frame).
+            audio_start_time: Start time in seconds for audio.
+            audio_max_duration: Max audio duration.
+            audio_conditioning_scale: Amplify audio tokens before DiT (default: 1.0).
+                Higher values increase audio adhesion at the cost of visual flexibility.
+
+        Returns:
+            Path to the output video file.
+        """
+        if self.low_memory:
+            mx.set_cache_limit(0)
+
+        if audio_path is None:
+            raise ValueError("audio_path is required for A2VidDistilledPipeline")
+
+        if audio_max_duration is None:
+            audio_max_duration = num_frames / frame_rate
+
+        # --- Encode audio ---
+        self._load_audio_encoder()
+        assert self.audio_encoder is not None
+        assert self.audio_processor is not None
+
+        audio_data = load_audio(
+            audio_path,
+            target_sample_rate=16000,
+            start_time=audio_start_time,
+            max_duration=audio_max_duration,
+        )
+        if audio_data is None:
+            raise ValueError(f"No audio found in {audio_path}")
+
+        audio_latent = encode_audio(
+            audio_data.waveform,
+            audio_data.sample_rate,
+            self.audio_encoder,
+            self.audio_processor,
+        )
+
+        audio_T = compute_audio_token_count(num_frames, frame_rate)
+        audio_latent = audio_latent[:, :, :audio_T, :]
+        audio_tokens, _ = self.audio_patchifier.patchify(audio_latent)
+        if audio_conditioning_scale != 1.0:
+            audio_tokens = audio_tokens * audio_conditioning_scale
+        mx.synchronize()
+        audio_T_actual = audio_tokens.shape[1]
+
+        if self.low_memory:
+            self.audio_conditioner.free()
+
+        # --- Text encoding (positive only, no CFG) ---
+        self._load_text_encoder()
+        with phase("Encoding prompt", verbose=self.verbose):
+            video_embeds, audio_embeds = self._encode_text(prompt)
+            _materialize(video_embeds, audio_embeds)
+        if self.low_memory:
+            self.prompt_encoder.free()
+            aggressive_cleanup()
+
+        # --- Load distilled DiT + upsampler (VAE encoder on demand) ---
+        self.load()
+        assert self.dit is not None
+        assert self.upsampler is not None
+
+        # --- Stage 1: half resolution ---
+        half_h, half_w = height // 2, width // 2
+        F, H_half, W_half = compute_video_latent_shape(num_frames, half_h, half_w)
+        video_shape = (1, F * H_half * W_half, 128)
+
+        video_positions_1 = compute_video_positions(F, H_half, W_half, frame_rate=frame_rate)
+        audio_positions = compute_audio_positions(audio_T_actual)
+
+        # I2V conditioning at half resolution
+        from ltx_pipelines_mlx.utils._orchestration import combined_image_conditionings
+        from ltx_pipelines_mlx.utils.args import ImageConditioningInput
+
+        enc_h_half = H_half * 32
+        enc_w_half = W_half * 32
+        resolved_images = list(images) if images else []
+        if image is not None and not resolved_images:
+            resolved_images = [ImageConditioningInput(path=image, frame_idx=0, strength=1.0)]
+        conditionings_1: list = []
+        if resolved_images:
+
+            def _encode_combined(encoder):
+                conds = combined_image_conditionings(
+                    resolved_images,
+                    enc_h=enc_h_half,
+                    enc_w=enc_w_half,
+                    spatial_dims=(F, H_half, W_half),
+                    video_encoder=encoder,
+                    frame_rate=frame_rate,
+                )
+                mx.synchronize()
+                return conds
+
+            conditionings_1 = self.image_conditioner(_encode_combined, free_after=self.low_memory)
+            if self.low_memory:
+                aggressive_cleanup()
+
+        # Video: noisy state. Audio: frozen from input (denoise_mask=0)
+        video_state_1 = create_noised_state(
+            base_shape=video_shape,
+            conditionings=conditionings_1,
+            spatial_dims=(F, H_half, W_half),
+            positions=video_positions_1,
+            seed=seed,
+            sigma=1.0,
+            initial_latent=None,
+            legacy_scalar_blend=True,
+        )
+
+        audio_state_1 = LatentState(
+            latent=audio_tokens,
+            clean_latent=audio_tokens,
+            denoise_mask=mx.zeros((1, audio_tokens.shape[1], 1), dtype=mx.bfloat16),
+            positions=audio_positions,
+        )
+
+        sigmas_1 = DISTILLED_SIGMAS[: stage1_steps + 1] if stage1_steps else DISTILLED_SIGMAS
+        x0_model = X0Model(self.dit)
+
+        self._pre_denoise_flush(video_state_1, audio_state_1)
+        output_1 = denoise_loop(
+            model=x0_model,
+            video_state=video_state_1,
+            audio_state=audio_state_1,
+            video_text_embeds=video_embeds,
+            audio_text_embeds=audio_embeds,
+            sigmas=sigmas_1,
+        )
+        if self.low_memory:
+            aggressive_cleanup()
+
+        # --- Upscale (denorm/upsample/renorm) ---
+        gen_tokens_1 = output_1.video_latent[:, : F * H_half * W_half, :]
+        video_half = self.video_patchifier.unpatchify(gen_tokens_1, (F, H_half, W_half))
+        H_full = H_half * 2
+        W_full = W_half * 2
+
+        def _upscale_and_optionally_encode(encoder):
+            v_mlx = video_half.transpose(0, 2, 3, 4, 1)
+            v_denorm = encoder.denormalize_latent(v_mlx).transpose(0, 4, 1, 2, 3)
+            v_up = self.upsampler(v_denorm)
+            v_up_renorm = encoder.normalize_latent(v_up.transpose(0, 2, 3, 4, 1)).transpose(0, 4, 1, 2, 3)
+            mx.synchronize()
+            conds: list = []
+            if resolved_images:
+                enc_h_full = H_full * 32
+                enc_w_full = W_full * 32
+                conds = combined_image_conditionings(
+                    resolved_images,
+                    enc_h=enc_h_full,
+                    enc_w=enc_w_full,
+                    spatial_dims=(F, H_full, W_full),
+                    video_encoder=encoder,
+                    frame_rate=frame_rate,
+                )
+            return v_up_renorm, conds
+
+        video_upscaled, conditionings_2 = self.image_conditioner(
+            _upscale_and_optionally_encode, free_after=self.low_memory
+        )
+        if self.low_memory:
+            self.upsampler = None
+            aggressive_cleanup()
+
+        # --- Stage 2: full resolution refine (no LoRA swap, already distilled) ---
+        video_tokens, _ = self.video_patchifier.patchify(video_upscaled)
+
+        sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
+        start_sigma = sigmas_2[0]
+
+        video_positions_2 = compute_video_positions(F, H_full, W_full, frame_rate=frame_rate)
+
+        video_state_2 = create_noised_state(
+            base_shape=video_tokens.shape,
+            conditionings=conditionings_2,
+            spatial_dims=(F, H_full, W_full),
+            positions=video_positions_2,
+            seed=seed + 2,
+            sigma=start_sigma,
+            initial_latent=video_tokens,
+            legacy_scalar_blend=True,
+        )
+
+        audio_state_2 = create_noised_state(
+            base_shape=audio_tokens.shape,
+            conditionings=[],
+            spatial_dims=(F, H_full, W_full),
+            positions=audio_positions,
+            seed=seed + 2,
+            sigma=start_sigma,
+            initial_latent=audio_tokens,
+        )
+
+        self._pre_denoise_flush(video_state_2, audio_state_2)
+        output_2 = denoise_loop(
+            model=x0_model,
+            video_state=video_state_2,
+            audio_state=audio_state_2,
+            video_text_embeds=video_embeds,
+            audio_text_embeds=audio_embeds,
+            sigmas=sigmas_2,
+        )
+        if self.low_memory:
+            aggressive_cleanup()
+
+        gen_tokens_2 = output_2.video_latent[:, : F * H_full * W_full, :]
+        video_latent = self.video_patchifier.unpatchify(gen_tokens_2, (F, H_full, W_full))
+
+        # --- Decode and save (mux original audio for max fidelity) ---
+        # Free DiT before loading decoders — saves ~11 GB peak.
+        self.dit = None
+        self._loaded = False
+        aggressive_cleanup()
+
+        self._load_decoders()
+
+        video_duration = num_frames / frame_rate
+        audio_data_48k = load_audio(
+            audio_path,
+            target_sample_rate=48000,
+            start_time=audio_start_time,
+            max_duration=video_duration,
+        )
+        if audio_data_48k is not None:
+            max_samples = int(video_duration * 48000)
+            waveform_48k = audio_data_48k.waveform[:, :, :max_samples]
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as _tmp:
+                temp_audio = _tmp.name
+            self._save_waveform(waveform_48k, temp_audio, sample_rate=48000)
+        else:
+            temp_audio = None
+
+        self.video_decoder_block.decode_and_stream(
+            video_latent,
+            output_path,
+            frame_rate=frame_rate,
+            audio_path=temp_audio,
+        )
+
+        if temp_audio is not None:
+            Path(temp_audio).unlink(missing_ok=True)
+
+        # Free all remaining Metal buffers so 24GB systems recover fully.
+        # Without this, VAE decoder (~1 GB), audio decoder + vocoder
+        # (~500 MB), and upsampler (~200 MB) stay pinned in Metal memory
+        # until process exit.
+        self.video_decoder_block.free()
+        self.audio_decoder_block.free()
+        self.upsampler = None
+        self.dit = None
+        self._loaded = False
+        aggressive_cleanup()
+
+        return output_path
+
+
+__all__ = ["A2VidDistilledPipeline"]

--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -5140,25 +5140,16 @@ def _new_job_id() -> str:
 
 
 def _validate_character_quality(form: dict[str, list[str]] | dict[str, str]) -> str | None:
-    """Defense-in-depth: when a character_id is set, the job must route
-    through the Q8 HQ pipeline (quality=high). Q4 distilled inference
-    fuses dev-trained character LoRAs into the wrong base (mismatched
-    sigma schedule) and produces a generic-everyone-looks-vaguely-like
-    -them result — confirmed empirically 2026-05-17 with the Eltrumpo
-    Q4-Balanced runs.
+    """Character mode is available on Q4 — LoRAs fuse into the distilled
+    base (identity match is mediocre per 2026-05-17 empirical test with
+    the Eltrumpo Q4-Balanced runs, but the render completes). When Q8 is
+    installed and the user picks quality=high, the Q8 HQ pipeline is used
+    and yields faithful identity.
 
-    The UI already prevents the bad combination by swapping the quality
-    strip to Q8-only when a character chip is selected, but a stale
-    form payload, a scripted /queue/batch caller, or a future tab that
-    forgets the chip-swap logic could submit the broken combo. Returning
-    an error keeps the trainer-base contract honest at the API boundary.
-
-    Also catches the loras=[] back-door: a scripted POST with a raw
-    train_character-kind LoRA in the `loras` JSON array (no character_id)
-    + quality=balanced would otherwise bypass this check — the UI's
-    updateQualityChipsForLora handles it client-side but the server
-    must enforce the same rule.
-
+    This function still catches the loras=[] back-door: a scripted POST
+    with a raw train_character-kind LoRA in the `loras` JSON array (no
+    character_id) + a non-high quality asserts a character LoRA against
+    the Q4 base, which produces the same mediocre-identity result.
     Returns None when valid, or an error string to surface as a 400."""
     def _f(name: str, default: str = "") -> str:
         v = form.get(name, default)
@@ -5168,21 +5159,15 @@ def _validate_character_quality(form: dict[str, list[str]] | dict[str, str]) -> 
     quality = _f("quality", "balanced").lower()
     cid = _f("character_id", "")
     if cid:
-        if quality != "high":
-            return (
-                f"character {cid!r} requires quality=high (Q8 HQ pipeline). "
-                f"Got quality={quality!r}. Character LoRAs are trained against "
-                f"the Q8 dev transformer's sigma schedule; the Q4 distilled "
-                f"pipeline fuses them into the wrong base and produces "
-                f"identity-mushed output. Pick Q8 Pro or Q8 Draft in the "
-                f"Character quality strip."
-            )
+        # Character mode on Q4 submits with Quick/Balanced/Standard.
+        # The identity match is imperfect but it renders and does not
+        # error. Q8 users who pick quality=high get the full fidelity
+        # path — no enforcement needed.
         return None
     # No character_id — but a raw train_character LoRA in `loras` triggers
-    # the same incompatibility. Resolve each entry's sidecar and refuse if
-    # any one of them is kind == "train_character" and quality != high.
-    if quality == "high":
-        return None  # the only outcome that needs to fail is non-high here
+    # the same quality concern. 2026-06-26: we allow it on Q4 (same
+    # mediocre-identity trade-off the user accepted by enabling character
+    # mode). Log a note but do not block.
     try:
         loras = parse_loras_from_form(form)
     except Exception:
@@ -5196,13 +5181,8 @@ def _validate_character_quality(form: dict[str, list[str]] | dict[str, str]) -> 
         except Exception:
             continue
         if (meta.get("kind") or "") == "train_character":
-            return (
-                f"a character LoRA ({p.name!r}) requires quality=high "
-                f"(Q8 HQ pipeline). Got quality={quality!r}. Character LoRAs "
-                f"are trained against the Q8 dev transformer's sigma schedule; "
-                f"the Q4 distilled pipeline fuses them into the wrong base "
-                f"and produces identity-mushed output. Pick Q8 Pro or Q8 Draft."
-            )
+            log_push(f"[character] raw train_character LoRA {p.name!r} at quality={quality!r} "
+                     f"on Q4 base — identity match may be imperfect")
     return None
 
 
@@ -5598,6 +5578,7 @@ def make_job(form: dict[str, list[str]] | dict[str, str], *,
             # 48-79 GB tier to dodge boundary OOM). User can override
             # explicitly to "full" or "off" via this form field.
             "stage2_image_conditioning": f("stage2_image_conditioning", "") or "",
+            "audio_conditioning_scale": float(f("audio_conditioning_scale", "1.0") or 1.0),
         },
         "command": None,
         "raw_path": None,
@@ -7034,31 +7015,42 @@ def run_job_inner(job: dict) -> None:
             subprocess.run(["open", str(out_path)], check=False)
         return
 
-    # Audio → Video (A2VidPipelineTwoStage).
+    # Audio → Video (A2VidPipelineTwoStage / A2VidDistilledPipeline).
     # Pipeline drives generation FROM the input audio waveform. Optional
     # reference image conditions frame 0 (single picture; pipeline cover-
     # crops to target). Original audio is muxed onto the output by the
     # pipeline itself — no panel-side mux needed (unlike i2v_clean_audio).
-    # Always Q8 dev + distilled LoRA stage 2 (the pipeline requires both).
+    #
+    # Two backends:
+    #   Q8 tier  → A2VidPipelineTwoStage (dev + CFG + TeaCache)
+    #   Q4 tier  → A2VidDistilledPipeline (distilled, no CFG, 8+3 steps)
     if mode == "a2v":
-        if not SYSTEM_CAPS["allows_q8"]:
-            raise RuntimeError(
-                f"Audio → Video isn't supported on the {SYSTEM_CAPS['label']} "
-                f"hardware tier — the Q8 dev transformer + audio VAE peak "
-                f"doesn't fit. Bump to 64+ GB."
-            )
-        a2v_missing = q8_missing_files()
-        if a2v_missing:
-            raise RuntimeError(
-                f"Audio → Video requires the full Q8 model at {Q8_LOCAL_PATH}. "
-                f"Missing {len(a2v_missing)} file(s): {', '.join(a2v_missing[:3])}"
-                f"{' …' if len(a2v_missing) > 3 else ''}. "
-                f"Run: hf download {MODEL_ID_HQ} --local-dir {Q8_LOCAL_PATH}"
-            )
+        uses_q8 = SYSTEM_CAPS["allows_q8"]
+        if uses_q8:
+            a2v_missing = q8_missing_files()
+            if a2v_missing:
+                push(f"Q8 not available ({len(a2v_missing)} file(s) missing) "
+                     f"— falling back to Q4 distilled A2V pipeline")
+                uses_q8 = False
+        if uses_q8:
+            action = "generate_a2v"
+            model_dir = str(Q8_LOCAL_PATH)
+            default_stage1 = 20
+            default_stage2 = 3
+        else:
+            action = "generate_a2v_distilled"
+            model_dir = str(Q4_LOCAL_PATH)
+            default_stage1 = 8
+            default_stage2 = 3
         audio_src = (p.get("audio") or "").strip()
         if not audio_src or not Path(audio_src).exists():
             raise RuntimeError(f"audio file not found: {audio_src}")
         width, height = int(p["width"]), int(p["height"])
+        # Clamp resolution on Q4 tier to keep within 24 GB budget.
+        max_dim = tier_max_dim("t2v")
+        if max_dim:
+            width = min(width, max_dim)
+            height = min(height, max_dim)
         frames = int(p["frames"])
         desc_stem = _descriptive_filename(
             p.get("label") or "", p.get("prompt") or "", fallback="a2v"
@@ -7087,41 +7079,39 @@ def run_job_inner(job: dict) -> None:
                 pass
         if ref_image_path and not Path(ref_image_path).exists():
             ref_image_path = None
-        # LoRAs flow through unchanged — useful for character A2V.
         a2v_loras = list(p.get("loras") or [])
         if p.get("hdr"):
             a2v_loras.append({
                 "path": CURATED_LORAS["hdr"]["repo_id"],
                 "strength": float(CURATED_LORAS["hdr"]["default_strength"]),
             })
-        job_spec = {
-            "action": "generate_a2v",
-            "id": job["id"],
-            "params": {
-                "model_dir": str(Q8_LOCAL_PATH),
-                "prompt": p["prompt"],
-                "negative_prompt": p.get("negative_prompt", ""),
-                "output_path": str(out_path),
-                "audio_path": audio_src,
-                "image": ref_image_path,
-                "height": height,
-                "width": width,
-                "frames": frames,
-                "frame_rate": float(FPS),
-                "seed": p["seed"],
-                "stage1_steps": int(p.get("stage1_steps", 20)),
-                "stage2_steps": int(p.get("stage2_steps", 3)),
-                "cfg_scale": float(p.get("cfg_scale", 3.0)),
-                "stg_scale": float(p.get("stg_scale", 1.0)),
-                "loras": a2v_loras,
-            },
+        a2v_params = {
+            "model_dir": model_dir,
+            "prompt": p["prompt"],
+            "negative_prompt": p.get("negative_prompt", ""),
+            "output_path": str(out_path),
+            "audio_path": audio_src,
+            "image": ref_image_path,
+            "height": height,
+            "width": width,
+            "frames": frames,
+            "frame_rate": float(FPS),
+            "seed": p["seed"],
+            "stage1_steps": int(p.get("stage1_steps", default_stage1)),
+            "stage2_steps": int(p.get("stage2_steps", default_stage2)),
+            "audio_conditioning_scale": float(p.get("audio_conditioning_scale", 1.0)),
         }
+        if uses_q8:
+            a2v_params["cfg_scale"] = float(p.get("cfg_scale", 3.0))
+            a2v_params["stg_scale"] = float(p.get("stg_scale", 1.0))
+            a2v_params["loras"] = a2v_loras
+        job_spec = {"action": action, "id": job["id"], "params": a2v_params}
         push(
-            f"Run A2V via helper: id={job['id']} {width}x{height} {frames}f · "
+            f"Run A2V ({'Q8' if uses_q8 else 'Q4-distilled'}) via helper: "
+            f"id={job['id']} {width}x{height} {frames}f · "
             f"audio={Path(audio_src).name}"
-            f"{' image=' + Path(ref_image_path).name if ref_image_path else ''} · "
-            f"{len(a2v_loras)} LoRA"
-            f"{'s' if len(a2v_loras) != 1 else ''}"
+            f"{' image=' + Path(ref_image_path).name if ref_image_path else ''}"
+            f" scale={a2v_params['audio_conditioning_scale']}"
         )
         result = HELPER.run(job_spec)
         if "seed_used" in result:
@@ -7129,13 +7119,13 @@ def run_job_inner(job: dict) -> None:
             p["seed_used"] = result["seed_used"]
         sidecar = {
             "output": str(out_path), "raw_output": str(out_path),
-            "params": {**p, "command": "generate_a2v", "audio": audio_src,
+            "params": {**p, "command": action, "audio": audio_src,
                        "image": ref_image_path},
             "started": job.get("started_at"),
             "elapsed_sec": round(time.time() - job["started_ts"], 2)
             if job.get("started_ts") else None,
             "video_duration_sec": video_duration(frames),
-            "fps": FPS, "model": str(Q8_LOCAL_PATH), "queue_id": job["id"],
+            "fps": FPS, "model": model_dir, "queue_id": job["id"],
             "helper_elapsed_sec": result.get("elapsed_sec"),
             "output_codec": output_codec_settings(),
         }
@@ -13540,15 +13530,9 @@ HTML = r"""<!doctype html>
        everything (no display: none rules apply when cap_tier="q8").
        Q4 path remains available to Q8 users via the Customize Compute
        toggle (Pass 6) for quick non-character drafts. */
-    body[data-cap-tier="q4"] #modeGroup [data-mode="keyframe"],
-    body[data-cap-tier="q4"] #modeGroup [data-mode="extend"],
-    body[data-cap-tier="q4"] #modeGroup [data-mode="character"],
-    body[data-cap-tier="q4"] #manualCharactersPickerSlot,
-    body[data-cap-tier="q4"] #charactersPickerDivider,
-    body[data-cap-tier="q4"] #qualityGroupCharacter,
-    body[data-cap-tier="q4"] #charSkipstepToggleWrap,
-    body[data-cap-tier="q4"] #workflowTabs button[data-workflow="audio"],
-    body[data-cap-tier="q4"] #qualityGroup [data-quality="high"] { display: none !important; }
+     body[data-cap-tier="q4"] #modeGroup [data-mode="keyframe"],
+     body[data-cap-tier="q4"] #modeGroup [data-mode="extend"],
+      body[data-cap-tier="q4"] #qualityGroup [data-quality="high"] { display: none !important; }
     /* Quality strip becomes a 3-col grid (Quick/Balanced/Standard)
        since the 4th column ("High") is gone. */
     body[data-cap-tier="q4"] #qualityGroup.quality-strip {
@@ -13577,6 +13561,19 @@ HTML = r"""<!doctype html>
     }
     textarea { min-height: 84px; resize: vertical; font-family: inherit; }
     textarea.avoid-textarea { min-height: 54px; }
+
+    /* Range slider strip (used in Audio Studio, etc.) */
+    .range-strip {
+      display: flex; align-items: center; gap: 10px;
+    }
+    .range-strip input[type="range"] {
+      flex: 1 1 auto; accent-color: var(--accent, #2f81f7);
+      padding: 0; border: none; background: none;
+    }
+    .range-val {
+      min-width: 32px; text-align: center; font-size: 14px;
+      font-weight: 600; color: var(--accent, #2f81f7);
+    }
 
     /* Pill button groups (mode/quality/aspect) */
     .pill-group {
@@ -21232,48 +21229,57 @@ HTML = r"""<!doctype html>
 
         <textarea id="audioStudioPrompt" class="composer-prompt" rows="4"
                   placeholder="A photoreal medium close-up of a woman speaking to camera, soft daylight, shallow depth of field, natural skin pores"></textarea>
+        <div class="composer-tools">
+          <button type="button" class="ghost-btn" id="audioStudioEnhanceBtn" onclick="audioStudioEnhancePrompt()" title="Use Gemma to rewrite your prompt"><svg class="ph" aria-hidden="true" style="margin-right:6px"><use href="#ph-sparkle-fill"/></svg>Enhance</button>
+          <span class="ct-spacer"></span>
+        </div>
       </div>
 
       <div class="studio-status-row" style="margin: 6px 0 -4px;">
         <span id="audioStudioStatus" class="hint"></span>
       </div>
 
-      <!-- Quick settings: aspect / duration / seed / quality.
-           Aspect maps to the same width/height table the Characters tab
-           uses (1024×576 high, 736×416 draft). Duration → frames at
-           8k+1 cadence the model expects. -->
+      <!-- Quick settings: width / height / duration / seed.
+           Width/height are free-form; the panel snaps to 32 px multiple.
+           Duration slider covers 1–30 s; JS rounds frames to 8k+1. -->
       <div class="quick-settings">
         <div>
           <div class="mini-fields">
             <div class="mf-cell">
-              <span class="mf-label">Aspect</span>
-              <select id="audioStudioAspect" style="padding:7px 9px;font-size:13px;">
-                <option value="16:9" selected>16:9 — 1024×576</option>
-                <option value="9:16">9:16 — 576×1024</option>
-                <option value="1:1">1:1 — 768×768</option>
-                <option value="4:3">4:3 — 832×608</option>
-              </select>
+              <span class="mf-label">Width</span>
+              <input type="number" id="audioStudioWidth" value="1024" min="256" max="1920" step="32">
             </div>
             <div class="mf-cell">
-              <span class="mf-label">Duration</span>
-              <select id="audioStudioDuration" style="padding:7px 9px;font-size:13px;">
-                <option value="5">5 s</option>
-                <option value="7" selected>7 s</option>
-                <option value="10">10 s</option>
-              </select>
+              <span class="mf-label">Height</span>
+              <input type="number" id="audioStudioHeight" value="576" min="256" max="1920" step="32">
             </div>
             <div class="mf-cell">
               <span class="mf-label">Seed</span>
               <input type="number" id="audioStudioSeed" value="-1" placeholder="-1 = random">
             </div>
           </div>
+          <div class="mf-cell" style="margin-top:8px">
+            <span class="mf-label">Duration</span>
+            <div class="range-strip">
+              <input type="range" id="audioStudioDuration" min="1" max="30" step="1" value="7"
+                     oninput="document.getElementById('audioStudioDurationVal').textContent=this.value + ' s'">
+              <span id="audioStudioDurationVal" class="range-val">7 s</span>
+            </div>
+          </div>
+          <div class="mf-cell" style="margin-top:8px">
+            <span class="mf-label">Audio conditioning strength</span>
+            <div class="range-strip">
+              <input type="range" id="audioConditioningScale" min="0.5" max="5.0" step="0.1" value="1.0"
+                     oninput="document.getElementById('audioConditioningScaleVal').textContent=this.value">
+              <span id="audioConditioningScaleVal" class="range-val">1.0</span>
+            </div>
+            <div class="hint" style="margin-top:2px">Higher = stronger audio adhesion, lower visual flexibility</div>
+          </div>
         </div>
       </div>
 
-      <div class="hint" style="margin-top:8px">
-        Audio → Video uses the Q8 dev transformer with audio conditioning.
-        Wall time is similar to High-quality I2V (~7–9 min on a 64 GB M-Max
-        for a 7 s 1024×576 clip).
+      <div class="hint" style="margin-top:8px" id="audioStudioHint">
+        Audio → Video uses audio conditioning during generation (not post-hoc mux). Some seeds may not work properly — retry if the mouth doesn't move.
       </div>
 
       <div class="form-action-footer" id="audioStudioFooter">
@@ -22415,12 +22421,13 @@ function syncAvoidRowFromValue() {
 }
 
 function setMode(mode) {
-  // Capability guard — Q4 (sub-48GB) tier can't run FFLF, Extend, or
-  // Character (HQ-only pipelines + Q8 trainer-base contract). CSS already
-  // hides the chips, but a stale localStorage, charactersLoadParams(), or
-  // a JS caller could still try to switch. Snap to t2v with a console
-  // warning so we never end up in an unrenderable mode by accident.
-  if (window.PHOSPHENE_CAP_TIER === 'q4' && (mode === 'keyframe' || mode === 'extend' || mode === 'character')) {
+  // Capability guard — Q4 (sub-48GB) tier can't run FFLF or Extend
+  // (Q8-only pipelines). CSS already hides the chips, but a stale
+  // localStorage or a JS caller could still try to switch. Snap to t2v
+  // with a console warning so we never end up in an unrenderable mode
+  // by accident. Character is available on Q4 (LoRA fuses into distilled
+  // base — identity match is mediocre but the render completes).
+  if (window.PHOSPHENE_CAP_TIER === 'q4' && (mode === 'keyframe' || mode === 'extend')) {
     console.warn(`setMode(${mode}): not available on Q4 tier — snapping to t2v`);
     mode = 't2v';
   }
@@ -22462,9 +22469,10 @@ function setMode(mode) {
   }
   if (mode === 'character') {
     // Character is a UI intent, not a backend mode — the hidden #mode
-    // field still ships 't2v' on submit. make_job sees character_id +
-    // routes to Q8 HQ. CSS-only chrome (chip strip + Q8 quality strip)
-    // makes the cascade visible.
+    // field still ships 't2v' on submit. make_job sees character_id and
+    // expands it into face+audio LoRAs. On Q8, the quality strip swaps
+    // to Q8 Draft/Pro; on Q4, the regular quality pills stay visible
+    // and the LoRAs fuse into the distilled base.
     if (studio) studio.classList.remove('show');
     if (train) train.classList.remove('show');
     if (genForm) genForm.style.display = '';
@@ -24545,6 +24553,24 @@ function audioStudioRenderSlots() {
   }
 }
 
+async function audioStudioEnhancePrompt() {
+  const ta = document.getElementById('audioStudioPrompt');
+  const original = ta.value.trim();
+  if (!original) { alert('Type a prompt before enhancing it.'); return; }
+  const btn = document.getElementById('audioStudioEnhanceBtn');
+  const originalLabel = btn.innerHTML;
+  btn.disabled = true;
+  btn.innerHTML = '<svg class="ph" aria-hidden="true" style="margin-right:6px;vertical-align:-2px"><use href="#ph-sparkle-fill"/></svg>Loading Gemma\u2026 (~15s)';
+  try {
+    const r = await fetch('/prompt/enhance', { method: 'POST', body: new URLSearchParams({ prompt: original, mode: 't2v' }) });
+    const res = await r.json();
+    if (res.error) { alert('Enhance failed: ' + res.error); return; }
+    if (confirm('Original:\n' + res.original + '\n\nEnhanced:\n' + res.enhanced + '\n\nReplace your prompt with the enhanced version?'))
+      { ta.value = res.enhanced; ta.dispatchEvent(new Event('input', { bubbles: true })); }
+  } catch (e) { alert('Enhance request failed: ' + (e.message || e)); }
+  finally { btn.disabled = false; btn.innerHTML = originalLabel; }
+}
+
 async function audioStudioGenerate() {
   if (AUDIO_STUDIO.busy) return;
   const status = document.getElementById('audioStudioStatus');
@@ -24558,23 +24584,16 @@ async function audioStudioGenerate() {
     if (status) status.textContent = 'Prompt is required.';
     return;
   }
-  // Aspect → width/height map. Snapped to multiples of 32 so the latent
-  // grid is exact (LTX requires HW % 32 == 0; the panel checks this in
-  // make_job too but we pre-snap to keep the user's chosen ratio).
-  const aspect = (document.getElementById('audioStudioAspect').value || '16:9');
-  const aspectMap = {
-    '16:9': [1024, 576],
-    '9:16': [576, 1024],
-    '1:1':  [768, 768],
-    '4:3':  [832, 608],
-  };
-  const [w, h] = aspectMap[aspect] || aspectMap['16:9'];
-  // Duration → frames at 8k+1 cadence the model expects.
+  // Width / height from free-form inputs; snap to 32 px multiple
+  // (LTX latent grid requirement).
+  const w = Math.max(32, Math.round(parseInt(document.getElementById('audioStudioWidth').value || '1024', 10) / 32) * 32);
+  const h = Math.max(32, Math.round(parseInt(document.getElementById('audioStudioHeight').value || '576', 10) / 32) * 32);
+  // Duration from slider → frames at 8k+1 cadence the model expects.
   const dur = parseInt(document.getElementById('audioStudioDuration').value || '7', 10);
-  // 24 fps → frames per second; snap to nearest 8k+1.
   const targetFrames = Math.max(1, Math.round(dur * 24));
   const frames = ((targetFrames - 1 + 7) >> 3 << 3) + 1;  // round up to 8k+1
   const seed = parseInt(document.getElementById('audioStudioSeed').value || '-1', 10);
+  const audioConditioningScale = parseFloat(document.getElementById('audioConditioningScale').value || '1.0');
 
   AUDIO_STUDIO.busy = true;
   if (btn) btn.disabled = true;
@@ -24594,7 +24613,8 @@ async function audioStudioGenerate() {
     fd.set('height', String(h));
     fd.set('frames', String(frames));
     fd.set('seed', String(seed));
-    fd.set('quality', 'high');  // A2V is always Q8 dev-class
+    fd.set('audio_conditioning_scale', String(audioConditioningScale));
+    fd.set('quality', 'high');  // A2V is always pipeline-class (Q8 dev or Q4 distilled)
     // No accel, no enhance — A2V uses A2VidPipelineTwoStage's own walks.
     fd.set('accel', 'off');
     fd.set('enhance', 'off');
@@ -27032,9 +27052,9 @@ function pickerSetImage(key, path, opts = {}) {
     // FFLF anchors framing on the start frame; I2V anchors on its single
     // image. End frame doesn't drive aspect (would override the start
     // frame). a2v_image lives in the Audio→Video tab which has its own
-    // aspect dropdown (#audioStudioAspect) — calling snapAspectToImage
-    // would change the GLOBAL #aspect selector, not the A2V one, so
-    // skip it for a2v_image to avoid silently mutating an unrelated mode.
+    // width/height inputs — calling snapAspectToImage would change the
+    // GLOBAL #aspect selector, not the A2V one, so skip it for a2v_image
+    // to avoid silently mutating an unrelated mode.
     if ((key === 'image' || key === 'start_image') && opts.snapAspect !== false) {
       snapAspectToImage(path);
     }
@@ -31342,6 +31362,10 @@ function selectManualCharacter(id) {
 // based on whether a character is currently selected. Idempotent — safe
 // to call any time the selection state changes.
 function _applyCharacterQualityStripVisibility() {
+  // Q4 tier keeps the regular quality pills (Quick/Balanced/Standard) —
+  // no Q8-only character quality strip. The character LoRA fuses into
+  // the Q4 distilled base; identity match is imperfect but it renders.
+  if (window.PHOSPHENE_CAP_TIER === 'q4') return;
   const def  = document.getElementById('qualityGroup');
   const char = document.getElementById('qualityGroupCharacter');
   const skipWrap = document.getElementById('charSkipstepToggleWrap');
@@ -32432,12 +32456,7 @@ function workflowSwitch(name) {
   // chip strip is integrated into Manual (T2V). If we get a stale
   // 'characters' value from localStorage, snap to 'manual'.
   if (name === 'characters') name = 'manual';
-  // Q4 cap-tier doesn't ship the audio workflow. If 'audio' is requested
-  // anyway (stale localStorage, Load Params on a historical A2V job,
-  // scripted caller), snap to 'manual' before any pane logic runs.
-  if (name === 'audio' && document.body.dataset.capTier === 'q4') {
-    name = 'manual';
-  }
+  // Q4 tier uses the distilled A2V pipeline (no Q8 dev required).
   document.querySelectorAll('#workflowTabs button[data-workflow]')
     .forEach(b => b.classList.toggle('active', b.dataset.workflow === name));
   const manual = document.getElementById('genForm');

--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -7046,7 +7046,7 @@ def run_job_inner(job: dict) -> None:
         if not audio_src or not Path(audio_src).exists():
             raise RuntimeError(f"audio file not found: {audio_src}")
         width, height = int(p["width"]), int(p["height"])
-        # Clamp resolution on Q4 tier to keep within 24 GB budget.
+        # Clamp resolution by tier cap (no-op when tier_max_dim returns 0).
         max_dim = tier_max_dim("t2v")
         if max_dim:
             width = min(width, max_dim)
@@ -13530,9 +13530,9 @@ HTML = r"""<!doctype html>
        everything (no display: none rules apply when cap_tier="q8").
        Q4 path remains available to Q8 users via the Customize Compute
        toggle (Pass 6) for quick non-character drafts. */
-     body[data-cap-tier="q4"] #modeGroup [data-mode="keyframe"],
-     body[data-cap-tier="q4"] #modeGroup [data-mode="extend"],
-      body[data-cap-tier="q4"] #qualityGroup [data-quality="high"] { display: none !important; }
+    body[data-cap-tier="q4"] #modeGroup [data-mode="keyframe"],
+    body[data-cap-tier="q4"] #modeGroup [data-mode="extend"],
+    body[data-cap-tier="q4"] #qualityGroup [data-quality="high"] { display: none !important; }
     /* Quality strip becomes a 3-col grid (Quick/Balanced/Standard)
        since the 4th column ("High") is gone. */
     body[data-cap-tier="q4"] #qualityGroup.quality-strip {

--- a/mlx_warm_helper.py
+++ b/mlx_warm_helper.py
@@ -102,6 +102,36 @@ MODEL_UPSCALE_ENABLED = os.environ.get("LTX_ENABLE_MODEL_UPSCALE", "").lower() i
 _USER_VAE_STREAMING_OVERRIDE = os.environ.get("LTX_VAE_STREAMING")
 
 
+def _log_memory_pressure() -> None:
+    """Emit a log line with current memory stats for diagnosing GPU timeouts."""
+    try:
+        import subprocess, re
+        total = int(subprocess.run(["sysctl", "-n", "hw.memsize"],
+            capture_output=True, text=True, timeout=1).stdout.strip())
+        vm = subprocess.run(["vm_stat"], capture_output=True, text=True, timeout=1).stdout
+        m = re.search(r"page size of (\d+)", vm)
+        page_size = int(m.group(1)) if m else 16384
+        def pages(name: str) -> int:
+            mm = re.search(rf"{re.escape(name)}:\s+(\d+)", vm)
+            return int(mm.group(1)) if mm else 0
+        used_bytes = (pages("Pages active") + pages("Pages wired down")
+                      + pages("Pages occupied by compressor")) * page_size
+        used_gb = used_bytes / 1024**3
+        pct = round(used_bytes / total * 100) if total else 0
+        emit({"event": "log", "line": f"[mem] used={used_gb:.1f}G/{total/1024**3:.0f}G ({pct}%)"})
+    except Exception:
+        pass
+
+
+def _aggressive_cleanup_before_generate() -> None:
+    """Minimize Metal heap fragmentation before pipeline generation."""
+    try:
+        from ltx_core_mlx.utils.memory import aggressive_cleanup as _ac
+        _ac()
+    except Exception:
+        pass
+
+
 def _apply_vae_streaming_decision(num_frames: int) -> None:
     """Set/unset os.environ['LTX_VAE_STREAMING'] for the upcoming decode.
     No-op if the user pinned a value at helper start time. Threshold reads
@@ -236,6 +266,8 @@ _hq_model_dir = None     # remember which model the HQ pipe was built against
 _a2v_pipe = None         # A2VidPipelineTwoStage (Q8 dev + distilled LoRA stage 2)
 _a2v_model_dir = None    # which model the A2V pipe was built against
 _a2v_lora_key: tuple | None = None  # LoRA fingerprint for current A2V cache
+_a2v_distilled_pipe = None   # A2VidDistilledPipeline (Q4 distilled, no CFG)
+_a2v_distilled_model_dir = None
 _pipe_lock = threading.Lock()
 
 
@@ -321,6 +353,7 @@ def release_pipelines(keep_kind=None):
     """
     global _t2v_pipe, _i2v_pipe, _extend_pipe, _hq_pipe, _kf_pipe, _hq_model_dir, _kf_model_dir
     global _a2v_pipe, _a2v_model_dir
+    global _a2v_distilled_pipe, _a2v_distilled_model_dir
     global _gemma_lm
     try:
         from ltx_core_mlx.utils.memory import aggressive_cleanup
@@ -340,6 +373,8 @@ def release_pipelines(keep_kind=None):
         _kf_pipe = None; _kf_model_dir = None; freed.append("Keyframe")
     if keep_kind != "a2v" and _a2v_pipe is not None:
         _a2v_pipe = None; _a2v_model_dir = None; freed.append("A2V")
+    if keep_kind != "a2v_distilled" and _a2v_distilled_pipe is not None:
+        _a2v_distilled_pipe = None; _a2v_distilled_model_dir = None; freed.append("A2V-distilled")
     # Always free Gemma LanguageModel when releasing for any pipeline —
     # ~6 GB persistent that competes with the dev transformer's headroom.
     # Re-loaded on demand by the next enhance call (one-time ~10s cost).
@@ -1079,6 +1114,39 @@ def get_a2v_pipe(model_dir: str, loras: list[dict] | None = None):
             _a2v_model_dir = model_dir
             _a2v_lora_key = fp
         return _a2v_pipe
+
+
+def get_a2v_distilled_pipe(model_dir: str):
+    """Returns A2VidDistilledPipeline lazily.
+
+    Q4-compatible distilled pipeline — no dev transformer, no CFG, 8+3 steps.
+    Cached on model_dir so switching between Q4 and Q8 paths rebuilds.
+    """
+    global _a2v_distilled_pipe, _a2v_distilled_model_dir
+    from a2vid_distilled import A2VidDistilledPipeline
+
+    _install_a2v_frame_rate_patch()
+
+    try:
+        from ltx_core_mlx.utils.memory import aggressive_cleanup as _ac
+    except Exception:
+        _ac = lambda: None
+    with _pipe_lock:
+        release_pipelines(keep_kind="a2v_distilled")
+        if _a2v_distilled_pipe is None or _a2v_distilled_model_dir != model_dir:
+            if _a2v_distilled_pipe is not None:
+                emit({"event": "log", "line": "model_dir changed; reloading A2V distilled pipeline."})
+                _a2v_distilled_pipe = None
+                _ac()
+            emit({"event": "log",
+                  "line": f"Loading A2V distilled pipeline (Q4 — {model_dir})..."})
+            _a2v_distilled_pipe = A2VidDistilledPipeline(
+                model_dir=model_dir,
+                gemma_model_id=GEMMA_PATH,
+                low_memory=LOW_MEMORY,
+            )
+            _a2v_distilled_model_dir = model_dir
+        return _a2v_distilled_pipe
 
 
 # ---- prompt enhancement (Gemma language model) ------------------------------
@@ -1895,6 +1963,7 @@ for line in sys.__stdin__:
                       "line": f"step:get_pipe kind={('i2v' if needs_image else 't2v')}"})
             pipe = get_pipe("i2v" if needs_image else "t2v", loras=loras)
             emit({"event": "log", "line": "step:get_pipe done"})
+            _log_memory_pressure()
             accel_mode = configure_acceleration(p.get("accel", "off"))
             negative_prompt = _clean_text(p.get("negative_prompt"))
             effective_prompt = _prompt_with_soft_negative(p["prompt"], negative_prompt)
@@ -1958,6 +2027,7 @@ for line in sys.__stdin__:
                 elif not upscaler_available():
                     emit({"event": "log", "line": "Sharper upscale requested but model weights missing — falling back to Lanczos."})
 
+            _aggressive_cleanup_before_generate()
             if use_model_upscale:
                 emit({"event": "log", "line": f"step:generate mode={mode} {kwargs['width']}x{kwargs['height']} {kwargs['num_frames']}f @{kwargs['frame_rate']:.1f}fps steps={kwargs['num_steps']} accel={accel_mode} upscale=model"})
                 # Step 1: generate latents (no save)
@@ -1981,7 +2051,8 @@ for line in sys.__stdin__:
                 # panel's wait_done while MLX tears down ~10 GB of Metal
                 # buffers + lazy graph nodes synchronously.
                 emit({"event": "log", "line": "step:decode_and_save done"})
-            else:
+            _aggressive_cleanup_before_generate()
+            if not use_model_upscale:
                 emit({"event": "log", "line": f"step:generate mode={mode} {kwargs['width']}x{kwargs['height']} {kwargs['num_frames']}f @{kwargs['frame_rate']:.1f}fps steps={kwargs['num_steps']} accel={accel_mode}"})
                 video_latent, audio_latent = _generate_latents(pipe, needs_image=needs_image, kwargs=kwargs)
                 emit({"event": "log", "line": "step:generate done"})
@@ -2471,6 +2542,79 @@ for line in sys.__stdin__:
         finally:
             # Clear so the next non-A2V action doesn't inherit a stale gate.
             _A2V_TC_CONFIG = None
+            _is_busy = False
+        continue
+
+    if action == "generate_a2v_distilled":
+        # Audio-to-Video via the Q4 distilled pipeline (no dev transformer,
+        # no CFG, 8+3 steps). Fits 24 GB systems where Q8 dev doesn't.
+        job_id = msg.get("id", "?")
+        p = msg.get("params", {}) or {}
+        model_dir = p.get("model_dir") or MODEL_ID
+        seed = int(p.get("seed", -1))
+        if seed == -1:
+            seed = random.randint(0, 2**31 - 1)
+        _is_busy = True
+        try:
+            t0 = time.time()
+            configure_acceleration("off")
+            audio_path = p.get("audio_path") or ""
+            if not audio_path:
+                raise RuntimeError("audio_path is required for A2V")
+            if not os.path.exists(audio_path):
+                raise RuntimeError(f"audio file not found: {audio_path}")
+            num_frames = int(p["frames"])
+            pipe = get_a2v_distilled_pipe(model_dir)
+            _apply_vae_streaming_decision(num_frames)
+            kwargs = dict(
+                prompt=p["prompt"],
+                output_path=p["output_path"],
+                audio_path=audio_path,
+                height=int(p["height"]),
+                width=int(p["width"]),
+                num_frames=num_frames,
+                frame_rate=float(p.get("frame_rate", 24.0)),
+                seed=seed,
+                stage1_steps=int(p.get("stage1_steps", 8)),
+                stage2_steps=int(p.get("stage2_steps", 3)),
+                audio_start_time=float(p.get("audio_start_time", 0.0)),
+                audio_conditioning_scale=float(p.get("audio_conditioning_scale", 1.0)),
+            )
+            ref_image = p.get("image") or None
+            if ref_image:
+                if not os.path.exists(ref_image):
+                    raise RuntimeError(f"reference image not found: {ref_image}")
+                kwargs["image"] = ref_image
+            amd = p.get("audio_max_duration")
+            if amd is not None:
+                try:
+                    kwargs["audio_max_duration"] = float(amd)
+                except (TypeError, ValueError):
+                    pass
+            emit({
+                "event": "log",
+                "line": (
+                    f"step:generate_a2v_distilled {kwargs['width']}x{kwargs['height']} "
+                    f"{kwargs['num_frames']}f @{kwargs['frame_rate']:.1f}fps "
+                    f"stage1={kwargs['stage1_steps']} stage2={kwargs['stage2_steps']} "
+                    f"audio={os.path.basename(audio_path)}"
+                    f" a2v_scale={kwargs.get('audio_conditioning_scale', 1.0)}"
+                    f"{' image=' + os.path.basename(ref_image) if ref_image else ''}"
+                ),
+            })
+            kwargs = _filter_unsupported_kwargs(pipe.generate_and_save, kwargs)
+            out_path = pipe.generate_and_save(**kwargs)
+            elapsed = round(time.time() - t0, 2)
+            _last_activity = time.time()
+            emit({
+                "event": "done", "id": job_id,
+                "output": str(out_path), "elapsed_sec": elapsed,
+                "seed_used": seed,
+            })
+        except Exception as exc:
+            _last_activity = time.time()
+            emit({"event": "error", "id": job_id, "error": str(exc), "trace": traceback.format_exc()})
+        finally:
             _is_busy = False
         continue
 

--- a/mlx_warm_helper.py
+++ b/mlx_warm_helper.py
@@ -1123,7 +1123,12 @@ def get_a2v_distilled_pipe(model_dir: str):
     Cached on model_dir so switching between Q4 and Q8 paths rebuilds.
     """
     global _a2v_distilled_pipe, _a2v_distilled_model_dir
-    from a2vid_distilled import A2VidDistilledPipeline
+    try:
+        from a2vid_distilled import A2VidDistilledPipeline
+    except ModuleNotFoundError:
+        raise RuntimeError(
+            "A2V distilled module not found — run Update to install it."
+        ) from None
 
     _install_a2v_frame_rate_patch()
 


### PR DESCRIPTION
Adds A2V Distilled Pipeline (a2vid_distilled.py) in phosphene root for
Q4-distilled audio-to-video generation. No ltx-2-mlx modifications
required — imports from stock ltx-pipelines-mlx package.

Key differences from the standard A2V path:
- a2vid_distilled.py lives in phosphene root (not inside ltx-2-mlx)
- mlx_warm_helper.py imports from the local a2vid_distilled module
- Distilled path (generate_a2v_distilled) passes audio_conditioning_scale
  (built into a2vid_distilled.py)
- Non-distilled path (generate_a2v) omits audio_conditioning_scale
  (upstream A2VidPipelineTwoStage does not accept it)
