### PR TITLE
fix(ui): mode-bar grid 5→6 columns to fit all 6 mode buttons

### DIFF
--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -15773,7 +15773,7 @@ HTML = r"""<!doctype html>
        small so the bar height stays low. */
     .mode-bar {
       display: grid;
-      grid-template-columns: repeat(5, 1fr);
+      grid-template-columns: repeat(6, 1fr);
       gap: 4px;
       padding: 4px;
       background: var(--panel);


### PR DESCRIPTION
## Problem
The mode bar has 6 buttons (text, character, image, fflf, keyframes, extend) but the CSS grid was set to repeat(5, 1fr) — 5 columns. This caused the only 6th button to wrap to a second row, unnecesarily extending the whole interface.

<img width="743" height="140" alt="image" src="https://github.com/user-attachments/assets/31bf8ef7-0934-4e03-84b5-f0509db53a25" />

## Fix
Changed grid-template-columns from repeat(5, 1fr) to repeat(6, 1fr) in the .mode-bar CSS class. All 6 buttons now display in a single row.

<img width="1143" height="355" alt="image" src="https://github.com/user-attachments/assets/dd7e9a28-7125-4cd0-a923-2a7e2737a4d9" />


1 line change in mlx_ltx_panel.py.