### PR TITLE
fix(install): expose Hailuo H3 on 48 GB Macs

### DIFF
--- a/docs/H3_ENGINE.md
+++ b/docs/H3_ENGINE.md
@@ -2,9 +2,16 @@
 
 MiniMax-H3 (FL2VA) takes one prompt and returns **picture, dialogue and sound
 generated together**. It ships as an **optional pack**, not part of the base
-install: ~75 GB of weights, a 64 GB+ Mac, and a licence with territory
-restrictions. LTX-2.3 stays the default engine and is completely untouched by
-any of this.
+install: ~75 GB of weights, a 48 GB+ Mac, and a licence with territory
+restrictions. On 48 GB-class Macs, the installer builds the reduced-RAM Q8 DiT
+pack automatically. LTX-2.3 stays the default engine and is completely
+untouched by any of this.
+
+## Install from Pinokio
+
+Stop Phosphene first—the launcher hides optional installers while the panel is
+running. In the Phosphene **Run** menu, click **Install Hailuo H3 (optional,
+~75 GB)**. The install is resumable if interrupted.
 
 ---
 

--- a/pinokio.js
+++ b/pinokio.js
@@ -20,11 +20,9 @@ const fs = require("fs")
 const os = require("os")
 const path = require("path")
 
-// Hailuo H3 (optional second video engine) needs ~40 GiB resident at peak, so
-// the menu entry only appears on 64 GB+ Macs. A 64 GB machine reports ~63.x GB
-// after firmware reservations, hence the 60 GB floor — the same number
-// h3_capable() uses in mlx_ltx_panel.py. Keep them in sync.
-const H3_MIN_BYTES = 60 * 1000 * 1000 * 1000
+// Hailuo H3's reduced-RAM Q8 engine supports 48 GB-class Macs. Use the same
+// effective floor as install_h3.js and H3_MIN_RAM_GB_Q8 in mlx_ltx_panel.py.
+const H3_MIN_BYTES = 46 * 1000 * 1000 * 1000
 
 function h3Capable() {
   try {
@@ -329,7 +327,7 @@ module.exports = {
     }
     if (!h3_ready && h3Capable()) {
       // Second VIDEO engine — joint picture + dialogue + sound. Opt-in only:
-      // ~75 GB, 64 GB+ Macs, MiniMax Community License with territory
+      // ~75 GB, 48 GB+ Macs, MiniMax Community License with territory
       // restrictions. Hidden entirely on machines that can't run it, so it
       // never reads as a missing piece of the base install.
       baseMenu.push(h3_repair


### PR DESCRIPTION
Closes #54

## Summary

- expose the optional Hailuo H3 installer on supported 48 GB-class Macs
- align the Pinokio launcher threshold with the Q8 preflight used by the installer and panel
- document that Phosphene must be stopped before optional installers appear

## Root cause

The v3.7.0 low-RAM H3 implementation updated `install_h3.js` and `mlx_ltx_panel.py`, but `pinokio.js` retained the previous 60 GB launcher threshold. The documentation also retained the old 64 GB requirement and did not mention the running-state menu behavior.

## Changes

| File | Change |
|---|---|
| `pinokio.js` | Lower H3 menu capability floor from 60 GB to 46 GB |
| `docs/H3_ENGINE.md` | Document 48 GB Q8 support and the stop-first Pinokio workflow |

## Validation

- [x] `node --check pinokio.js`
- [x] `git diff --check`
- [x] Verified a 48 GB Mac reports 51,539,607,552 bytes and passes the corrected gate
- [x] Manually confirmed the H3 installer appears after stopping Phosphene
