### PR TITLE
feat(h3): add local LoRA file import

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ New workflow tab in 3.0. WAV or MP3 in, MP4 out — the audio drives motion in t
 
 Drop `.safetensors` into `mlx_models/loras/` for immediate use, or browse and install LTX LoRAs from CivitAI inside the panel (per-row rename, download, companion-aware delete). Character bundles live alongside style LoRAs and are filtered out of the regular picker so they don't show up twice.
 
+**MiniMax H3 LoRAs use a separate library:** drop a converted H3 adapter into
+`mlx_models/hailuo-h3/loras/`, switch the Video engine to **Hailuo H3**, and
+press the LoRAs panel's Rescan button. H3 accepts the runner layout with paired
+`lora_A` / `lora_B` tensors and lets you choose its strength in the picker. A
+raw Kohya file (`lora_down`, `lora_up`, and `.alpha`) is deliberately rejected:
+renaming it would ignore its required alpha/rank scaling. The H3 CivitAI filter
+also routes compatible downloads to this library; H3 uses one adapter at a
+time. If Turbo is selected, turn it off or choose **My LoRA** in the Adapter
+control to spend that slot on your custom LoRA for the render.
+
 ### HTTP API
 
 Everything the panel does is reachable over plain HTTP on `127.0.0.1:8198`. Queue video jobs, generate images, train characters, manage LoRAs, poll status, fetch outputs — all from `curl`, a Python script, or an external agent like Claude Code or Codex. The panel UI is just one client; nothing about the feature set is exclusive to it.

--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -9521,15 +9521,24 @@ def _h3_lora_prepare(path: Path) -> dict:
     header, buf_start = _safetensors_header(path)
     _validate_h3_lora_payload(path, header, buf_start)
     meta = header.get("__metadata__") or {}
+    safe_scale_one_note = False
     if isinstance(meta, dict) and meta.get("alpha") is not None:
         try:
             if not math.isfinite(float(str(meta["alpha"]))):
                 raise ValueError
         except (TypeError, ValueError):
-            raise RuntimeError(f"{path.name} has an unreadable metadata alpha value.")
+            # The one known conversion marker is descriptive, not numeric:
+            # the converter already folded alpha/rank into the adapter and
+            # records that its effective scale is exactly 1.0.
+            safe_scale_one_note = bool(re.fullmatch(
+                r"\s*alpha\s*==\s*rank\s*;\s*scale\s*=\s*1(?:\.0+)?\s*",
+                str(meta["alpha"]), flags=re.IGNORECASE))
+            if not safe_scale_one_note:
+                raise RuntimeError(f"{path.name} has an unreadable metadata alpha value.")
     scale, evidence = _h3_lora_effective_alpha(path, header, buf_start)
     declares_alpha = (any(k != "__metadata__" and k.endswith(".alpha") for k in header)
-                      or (isinstance(meta, dict) and meta.get("alpha") is not None))
+                      or (isinstance(meta, dict) and meta.get("alpha") is not None
+                          and not safe_scale_one_note))
     if declares_alpha and scale is None:
         raise RuntimeError(f"{path.name} declares alpha but it cannot be applied safely.")
     if scale is not None and not math.isclose(scale, 1.0, rel_tol=1e-6,

--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -26,6 +26,7 @@ import select
 import shlex
 import shutil
 import signal
+import struct
 import subprocess
 import sys
 import threading
@@ -9000,6 +9001,11 @@ H3_LORAS_DIRNAME = "loras"
 H3_LORA_MAX_STACK = 1
 H3_LORA_SLOTS = ("turbo", "user")
 H3_LORA_SLOT_DEFAULT = "turbo"
+# `_parse_multipart_form` reads the request body into memory. Community H3
+# adapters are normally a few hundred MB, so 512 MiB admits real files while
+# keeping a malformed local request from consuming the whole machine.
+H3_LORA_UPLOAD_MAX_BYTES = 512 * 1024 * 1024
+H3_LORA_IMPORT_LOCK = threading.Lock()
 H3_LORA_STACK_NOTE = (
     "H3's runner has ONE adapter slot (`--lora` takes a single path), so a "
     "LoRA and Turbo can't both run. Pick which one this render uses.")
@@ -9046,6 +9052,60 @@ def _safe_h3_loras_dir() -> Path:
     d = _h3_loras_dir()
     d.mkdir(parents=True, exist_ok=True)
     return d
+
+
+def import_h3_lora_file(filename: str, data: bytes) -> dict:
+    """Stage, validate, and atomically install one user-selected H3 LoRA.
+
+    The browser chooser is intentionally not a generic file drop: accepting a
+    raw Kohya adapter would leave a permanently failing row in the library.
+    Stage the bytes under a hidden sibling, run the same layout preparation the
+    CivitAI path and render path use, then replace into the visible library
+    only after that succeeds. A refusal therefore leaves no misleading file.
+    """
+    raw_name = Path(str(filename or "")).name
+    safe_name = re.sub(r"[^A-Za-z0-9._-]+", "_", raw_name).strip("._")
+    if not safe_name or not safe_name.lower().endswith(".safetensors"):
+        raise ValueError("choose a .safetensors H3 LoRA file")
+    if not data:
+        raise ValueError("the selected file is empty")
+    if len(data) > H3_LORA_UPLOAD_MAX_BYTES:
+        raise ValueError(
+            f"the selected file is larger than "
+            f"{H3_LORA_UPLOAD_MAX_BYTES // (1024 * 1024)} MB")
+
+    # Handler instances run in parallel. Reserve the name across the complete
+    # stage → validate → publish sequence so a second request cannot replace a
+    # file whose first import checked `target.exists()` one instruction earlier.
+    with H3_LORA_IMPORT_LOCK:
+        base = _safe_h3_loras_dir()
+        target = base / safe_name
+        if target.exists():
+            raise FileExistsError(
+                f"{safe_name} is already in the H3 LoRA library; remove or rename "
+                "the existing file before importing another one")
+        tmp = base / f".{safe_name}.{os.getpid()}.{threading.get_ident()}.uploading"
+        try:
+            with tmp.open("xb") as fh:
+                fh.write(data)
+                fh.flush()
+                os.fsync(fh.fileno())
+            layout = _h3_lora_prepare(tmp)
+            os.replace(tmp, target)
+        except Exception:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            raise
+    push(f"[h3:lora] imported {target.name} ({layout['pairs']} module pair(s))")
+    return {
+        "path": str(target),
+        "filename": target.name,
+        "layout": layout["layout"],
+        "converted": bool(layout["converted"]),
+        "pairs": int(layout["pairs"]),
+    }
 
 
 def _lora_is_h3_lane(path_str) -> bool:
@@ -9099,6 +9159,126 @@ def _safetensors_header(path: Path) -> tuple[dict, int]:
     if not isinstance(header, dict):
         raise RuntimeError(f"{path.name} has a safetensors header that isn't an object.")
     return header, 8 + n
+
+
+def _validate_h3_lora_payload(path: Path, header: dict, buf_start: int) -> None:
+    """Reject a structurally incomplete adapter before it reaches the runner.
+
+    Header-only inspection is deliberately cheap, but it is not enough for an
+    upload endpoint: a forged header can advertise A/B tensors whose byte
+    ranges do not exist.  Validate only the tensors that make an H3 adapter
+    loadable, without loading them into MLX.  This keeps malformed files out
+    of the library and turns a late runner failure into an actionable import
+    error.
+    """
+    widths = {
+        "BOOL": 1, "U8": 1, "I8": 1, "U16": 2, "I16": 2,
+        "U32": 4, "I32": 4, "F16": 2, "BF16": 2, "U64": 8,
+        "I64": 8, "F32": 4, "F64": 8,
+        "F8_E4M3FN": 1, "F8_E4M3FNUZ": 1, "F8_E5M2": 1,
+        "F8_E5M2FNUZ": 1,
+    }
+    try:
+        buffer_bytes = path.stat().st_size - buf_start
+    except OSError as exc:
+        raise RuntimeError(f"{path.name} cannot be read ({exc}).")
+    if buffer_bytes < 0:
+        raise RuntimeError(f"{path.name} is truncated before its tensor buffer.")
+
+    entries = {k: v for k, v in header.items() if k != "__metadata__"}
+    a_names = {k[: -len(_H3_LORA_A_SUFFIX)] for k in entries
+               if k.endswith(_H3_LORA_A_SUFFIX)}
+    b_names = {k[: -len(_H3_LORA_B_SUFFIX)] for k in entries
+               if k.endswith(_H3_LORA_B_SUFFIX)}
+    if a_names != b_names:
+        missing_a = sorted(b_names - a_names)
+        missing_b = sorted(a_names - b_names)
+        detail = (f"missing lora_A for {missing_a[0]}" if missing_a else
+                  f"missing lora_B for {missing_b[0]}")
+        raise RuntimeError(f"{path.name} has unmatched H3 LoRA tensors ({detail}).")
+
+    def validate_tensor(key: str, entry: object) -> list[int]:
+        if not isinstance(entry, dict):
+            raise RuntimeError(f"{path.name} has an invalid tensor entry for {key!r}.")
+        dtype = str(entry.get("dtype") or "")
+        width = widths.get(dtype)
+        shape = entry.get("shape")
+        offsets = entry.get("data_offsets")
+        if width is None or not isinstance(shape, list) or len(shape) != 2:
+            raise RuntimeError(f"{path.name} has an unsupported H3 LoRA tensor {key!r}.")
+        try:
+            dims = [int(dim) for dim in shape]
+            start, end = [int(off) for off in offsets]
+        except (TypeError, ValueError):
+            raise RuntimeError(f"{path.name} has invalid offsets for {key!r}.")
+        if (len(offsets) != 2 or any(dim <= 0 for dim in dims) or start < 0 or
+                end < start or end > buffer_bytes):
+            raise RuntimeError(f"{path.name} is truncated or has invalid offsets for {key!r}.")
+        expected = width * dims[0] * dims[1]
+        if end - start != expected:
+            raise RuntimeError(f"{path.name} has inconsistent shape or offsets for {key!r}.")
+        return dims
+
+    for module in sorted(a_names):
+        a_shape = validate_tensor(module + _H3_LORA_A_SUFFIX,
+                                  entries[module + _H3_LORA_A_SUFFIX])
+        b_shape = validate_tensor(module + _H3_LORA_B_SUFFIX,
+                                  entries[module + _H3_LORA_B_SUFFIX])
+        if a_shape[0] != b_shape[1]:
+            raise RuntimeError(
+                f"{path.name} has incompatible LoRA rank for {module!r}.")
+
+    # A declared alpha must be readable.  The runner ignores alpha entirely,
+    # so silently skipping a malformed entry would recreate the wrong-strength
+    # failure this endpoint is meant to prevent.
+    scalar_widths = {"F64": 8, "F32": 4, "F16": 2, "BF16": 2,
+                     "I64": 8, "I32": 4}
+    for key, entry in entries.items():
+        if not key.endswith(".alpha"):
+            continue
+        if not isinstance(entry, dict):
+            raise RuntimeError(f"{path.name} has an invalid alpha entry for {key!r}.")
+        dtype = str(entry.get("dtype") or "")
+        shape, offsets = entry.get("shape"), entry.get("data_offsets")
+        try:
+            start, end = [int(off) for off in offsets]
+        except (TypeError, ValueError):
+            raise RuntimeError(f"{path.name} has invalid alpha offsets for {key!r}.")
+        scalar = shape == [] or shape == [1]
+        if (dtype not in scalar_widths or not scalar or len(offsets) != 2 or
+                start < 0 or end > buffer_bytes or
+                end - start != scalar_widths[dtype]):
+            raise RuntimeError(f"{path.name} has an unreadable alpha value for {key!r}.")
+
+    targets = _h3_lora_target_modules()
+    if targets is not None:
+        unknown = sorted(module for module in a_names if module not in targets)
+        if unknown:
+            raise RuntimeError(
+                f"{path.name} targets no module in the installed H3 transformer "
+                f"({unknown[0]!r}).")
+
+
+def _h3_lora_target_modules() -> set[str] | None:
+    """Return installed H3 DiT module names, or None until its weights exist.
+
+    A syntactically valid A/B pair is still a silent no-op if its module name
+    belongs to another MiniMax variant.  Read just the installed DiT header at
+    import time and compare module stems; a machine without H3 weights can
+    still curate its library for a later model download.
+    """
+    for root in _h3_model_roots():
+        dit = root / "deepbeep-pruned-bf16" / H3_DIT_FILENAME
+        if not dit.is_file():
+            continue
+        try:
+            header, _ = _safetensors_header(dit)
+        except Exception as exc:
+            raise RuntimeError(
+                f"could not inspect the installed H3 transformer ({exc}).")
+        return {key[: -len(".weight")] for key in header
+                if key != "__metadata__" and key.endswith(".weight")}
+    return None
 
 
 def _h3_lora_effective_alpha(path: Path, header: dict,
@@ -9333,11 +9513,34 @@ def _h3_lora_prepare(path: Path) -> dict:
     gets the same treatment instead of failing inside the runner). Idempotent:
     a bare-layout file is inspected and returned untouched."""
     info = _h3_lora_layout(path)
+    # Classify first so raw Kohya/diffusers files receive their useful
+    # conversion diagnosis even when their tensor payload is incomplete.
+    if not info["ok"] and not info["convertible"]:
+        raise RuntimeError(f"{path.name}: {info['reason']}")
+
+    header, buf_start = _safetensors_header(path)
+    _validate_h3_lora_payload(path, header, buf_start)
+    meta = header.get("__metadata__") or {}
+    if isinstance(meta, dict) and meta.get("alpha") is not None:
+        try:
+            if not math.isfinite(float(str(meta["alpha"]))):
+                raise ValueError
+        except (TypeError, ValueError):
+            raise RuntimeError(f"{path.name} has an unreadable metadata alpha value.")
+    scale, evidence = _h3_lora_effective_alpha(path, header, buf_start)
+    declares_alpha = (any(k != "__metadata__" and k.endswith(".alpha") for k in header)
+                      or (isinstance(meta, dict) and meta.get("alpha") is not None))
+    if declares_alpha and scale is None:
+        raise RuntimeError(f"{path.name} declares alpha but it cannot be applied safely.")
+    if scale is not None and not math.isclose(scale, 1.0, rel_tol=1e-6,
+                                               abs_tol=1e-6):
+        raise RuntimeError(
+            f"{path.name}: {evidence}; the H3 loader does not apply "
+            "alpha/rank. Re-export it with alpha/rank folded into lora_B "
+            "before importing.")
     if info["ok"]:
         return {"layout": "bare", "converted": False, "prefix": "",
                 "pairs": info["pairs"]}
-    if not info["convertible"]:
-        raise RuntimeError(f"{path.name}: {info['reason']}")
     n = _h3_lora_strip_prefix(path, info["prefix"])
     push(f"[h3:lora] {path.name}: stripped `{info['prefix']}` from {n} keys "
          f"(ComfyUI repack → bare layout; tensors untouched)")
@@ -25623,6 +25826,35 @@ class Handler(BaseHTTPRequestHandler):
             self._json({"ok": True, "status": "downloading"}, 202)
             return
 
+        # H3 LoRA import. This is deliberately a separate endpoint from
+        # /upload: reference media can be any image/audio, whereas an H3
+        # adapter must pass its model-layout gate BEFORE it lands in the picker.
+        if path == "/h3/loras/import" and ctype.startswith("multipart/form-data"):
+            try:
+                clen = int(self.headers.get("Content-Length") or "0")
+            except ValueError:
+                clen = 0
+            if clen <= 0:
+                self._json({"ok": False, "error": "Content-Length required"}, 411)
+                return
+            if clen > H3_LORA_UPLOAD_MAX_BYTES:
+                self._json({"ok": False,
+                            "error": f"upload too large (max "
+                                     f"{H3_LORA_UPLOAD_MAX_BYTES // (1024 * 1024)} MB)"}, 413)
+                return
+            try:
+                form = _parse_multipart_form(self.rfile, ctype, clen)
+                fld = form["file"] if "file" in form else None
+                if fld is None or not getattr(fld, "filename", None):
+                    raise ValueError("choose one .safetensors file")
+                imported = import_h3_lora_file(str(fld.filename), fld.file.read())
+                self._json({"ok": True, **imported})
+            except (ValueError, FileExistsError, RuntimeError) as exc:
+                self._json({"ok": False, "error": str(exc)}, 400)
+            except Exception as exc:
+                self._json({"ok": False, "error": f"import failed: {exc}"}, 500)
+            return
+
         # Multipart upload
         if path == "/upload" and ctype.startswith("multipart/form-data"):
             # Hard cap on body size so a misbehaving / malicious caller can't
@@ -40416,6 +40648,10 @@ HTML = r"""<!doctype html>
               <button type="button" class="loras-icon-btn"
                       title="Rescan mlx_models/loras/ for new files"
                       onclick="event.stopPropagation(); event.preventDefault(); refreshLoras()"><svg class="ph" aria-hidden="true"><use href="#ph-arrow-clockwise-bold"/></svg></button>
+              <input type="file" id="h3LoraImportFile" accept=".safetensors,application/octet-stream" hidden
+                     onchange="importH3Lora(this.files[0]); this.value = ''">
+              <button type="button" class="loras-browse-btn" id="h3LoraImportBtn" hidden
+                      onclick="event.stopPropagation(); event.preventDefault(); document.getElementById('h3LoraImportFile').click()">Import H3 LoRA</button>
               <button type="button" class="loras-browse-btn"
                       onclick="event.stopPropagation(); event.preventDefault(); openCivitaiModal()"><svg class="ph" aria-hidden="true" style="margin-right:6px;vertical-align:-2px"><use href="#ph-magnifying-glass"/></svg>Browse CivitAI</button>
             </span>
@@ -55981,11 +56217,38 @@ function _syncLoraPickerForEngine() {
       ? (_lorasDirs.h3 || 'the Hailuo H3 pack’s loras/ folder')
       : (_lorasDirs.ltx || 'mlx_models/loras/');
   }
+  const importBtn = document.getElementById('h3LoraImportBtn');
+  if (importBtn) importBtn.hidden = tag !== 'video:h3';
   if (typeof renderLorasList === 'function') { try { renderLorasList(); } catch (_) {} }
   // Re-serialize: the lane guard in _serializeLoras is what keeps the other
   // engine's chips off the wire, and it has to re-run when the lane changes.
   if (typeof _serializeLoras === 'function') { try { _serializeLoras(); } catch (_) {} }
   if (typeof renderH3LoraSlot === 'function') { try { renderH3LoraSlot(); } catch (_) {} }
+}
+
+async function importH3Lora(file) {
+  if (!file) return;
+  if (!/\.safetensors$/i.test(file.name || '')) {
+    alert('Choose a .safetensors Hailuo H3 LoRA file.');
+    return;
+  }
+  const btn = document.getElementById('h3LoraImportBtn');
+  const original = btn ? btn.textContent : '';
+  if (btn) { btn.disabled = true; btn.textContent = 'Importing…'; }
+  const fd = new FormData();
+  fd.append('file', file, file.name);
+  try {
+    const r = await fetch('/h3/loras/import', { method: 'POST', body: fd });
+    const data = await r.json();
+    if (!r.ok || !data.ok) throw new Error(data.error || `HTTP ${r.status}`);
+    await refreshLoras();
+    const converted = data.converted ? ' Key namespace converted safely.' : '';
+    alert(`Imported ${data.filename} (${data.pairs} module pairs).${converted}`);
+  } catch (e) {
+    alert(`H3 LoRA import failed: ${e.message || e}`);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = original || 'Import H3 LoRA'; }
+  }
 }
 
 // The H3-lane LoRA (at most one) currently picked, as a picker row — or null.

--- a/mlx_ltx_panel.py
+++ b/mlx_ltx_panel.py
@@ -56492,12 +56492,17 @@ function renderLorasList() {
         </div>`;
     } else if (modeTag === 'video:h3') {
       // Its own empty state, not the LTX one: the two libraries are separate
-      // directories and the CivitAI filter to reach for is a different pill.
+      // directories. CivitAI is convenient, but a custom adapter someone
+      // already has must be just as discoverable: it only needs the runner's
+      // lora_A/lora_B layout in the H3 library. The layout gate below keeps a
+      // raw Kohya file visible with its conversion reason instead of letting a
+      // bad adapter reach a long render.
       wrap.innerHTML = `
         <div class="hint" style="padding:14px 8px;text-align:center;line-height:1.6;">
           <div style="margin-bottom:4px;color:var(--fg);"><strong>No Hailuo H3 LoRAs in your library.</strong></div>
           <div>H3 has its own library — your LTX LoRAs can't load here, and H3's can't load on LTX.</div>
-          <div style="margin-top:6px;">Install one via <strong>Browse CivitAI</strong> above (the <strong>Hailuo H3</strong> pill), and it lands in <code>${escapeHtml(_lorasDirs.h3 || 'the H3 pack’s loras/ folder')}</code>.</div>
+          <div style="margin-top:6px;">Drop a converted H3 <code>.safetensors</code> with <code>lora_A</code> / <code>lora_B</code> tensors into <code>${escapeHtml(_lorasDirs.h3 || 'the H3 pack’s loras/ folder')}</code>, then press Rescan.</div>
+          <div style="margin-top:6px;">Or install one via <strong>Browse CivitAI</strong> above using the <strong>Hailuo H3</strong> CivitAI filter.</div>
         </div>`;
     } else {
       wrap.innerHTML = `<div class="hint" style="padding:8px 0;">No LoRAs available.</div>`;

--- a/test_h3_lora_file_import.py
+++ b/test_h3_lora_file_import.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Contract tests for the local H3 LoRA file-import path."""
+from __future__ import annotations
+
+import json
+import os
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+STATE = Path(tempfile.mkdtemp(prefix="phos-h3-file-import-"))
+os.environ["LTX_STATE_DIR"] = str(STATE)
+os.environ["PHOSPHENE_ANALYTICS_DISABLED"] = "1"
+os.environ["PHOSPHENE_DISABLE_VERSION_CHECK"] = "1"
+
+import mlx_ltx_panel as P
+
+
+def _safetensors_lora(*, alpha: float | None = None,
+                      module: str = "blocks.24.attn.qkv_proj") -> bytes:
+    """A tiny but complete F32 A/B safetensors payload for import validation."""
+    names = (
+        module + ".lora_A.weight",
+        module + ".lora_B.weight",
+    )
+    values = [(name, struct.pack("<f", 0.0)) for name in names]
+    if alpha is not None:
+        values.append((module + ".alpha", struct.pack("<f", alpha)))
+    header = {}
+    offset = 0
+    for key, raw in values:
+        header[key] = {"dtype": "F32",
+                       "shape": [1] if key.endswith(".alpha") else [1, 1],
+                       "data_offsets": [offset, offset + len(raw)]}
+        offset += len(raw)
+    encoded = json.dumps(header).encode("utf-8")
+    return len(encoded).to_bytes(8, "little") + encoded + b"".join(raw for _, raw in values)
+
+
+def _kohya_header() -> bytes:
+    header = {
+        "lora_unet_blocks_24_attn_qkv_proj.lora_down.weight": {"dtype": "F32", "shape": [1, 1], "data_offsets": [0, 0]},
+        "lora_unet_blocks_24_attn_qkv_proj.lora_up.weight": {"dtype": "F32", "shape": [1, 1], "data_offsets": [0, 0]},
+        "lora_unet_blocks_24_attn_qkv_proj.alpha": {"dtype": "F32", "shape": [1, 1], "data_offsets": [0, 0]},
+    }
+    encoded = json.dumps(header).encode("utf-8")
+    return len(encoded).to_bytes(8, "little") + encoded
+
+
+class TestH3LoraFileImport(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="phos-h3-lora-import-")
+        self.dir = Path(self.tmp.name)
+        self.old_dir = P._safe_h3_loras_dir
+        P._safe_h3_loras_dir = lambda: self.dir
+
+    def tearDown(self):
+        P._safe_h3_loras_dir = self.old_dir
+        self.tmp.cleanup()
+
+    def test_imports_runner_layout_into_h3_library(self):
+        payload = _safetensors_lora()
+        result = P.import_h3_lora_file("MysticXXX_MMH3-V4.safetensors", payload)
+
+        target = self.dir / "MysticXXX_MMH3-V4.safetensors"
+        self.assertEqual(Path(result["path"]), target)
+        self.assertTrue(target.is_file())
+        self.assertEqual(result["layout"], "bare")
+        self.assertFalse(result["converted"])
+
+    def test_refuses_raw_kohya_and_leaves_no_file(self):
+        payload = _kohya_header()
+
+        with self.assertRaisesRegex(RuntimeError, "kohya.*alpha"):
+            P.import_h3_lora_file("raw-kohya.safetensors", payload)
+
+        self.assertEqual(list(self.dir.iterdir()), [])
+
+    def test_refuses_non_safetensors_uploads(self):
+        with self.assertRaisesRegex(ValueError, "\.safetensors"):
+            P.import_h3_lora_file("adapter.zip", b"not an adapter")
+
+    def test_refuses_non_unit_alpha_without_leaving_a_file(self):
+        with self.assertRaisesRegex(RuntimeError, "alpha/rank.*folded"):
+            P.import_h3_lora_file("needs-scale.safetensors", _safetensors_lora(alpha=8.0))
+
+        self.assertEqual(list(self.dir.iterdir()), [])
+
+    def test_refuses_unreadable_alpha_without_leaving_a_file(self):
+        payload = _safetensors_lora(alpha=1.0)[:-4]
+        with self.assertRaisesRegex(RuntimeError, "alpha|truncated|offsets"):
+            P.import_h3_lora_file("bad-alpha.safetensors", payload)
+
+        self.assertEqual(list(self.dir.iterdir()), [])
+
+    def test_refuses_modules_missing_from_the_installed_transformer(self):
+        old_targets = P._h3_lora_target_modules
+        P._h3_lora_target_modules = lambda: {"blocks.24.attn.qkv_proj"}
+        try:
+            with self.assertRaisesRegex(RuntimeError, "targets no module"):
+                P.import_h3_lora_file(
+                    "wrong-model.safetensors",
+                    _safetensors_lora(module="blocks.24.attn.typo"))
+        finally:
+            P._h3_lora_target_modules = old_targets
+
+        self.assertEqual(list(self.dir.iterdir()), [])
+
+    def test_refuses_a_header_only_adapter(self):
+        header_only = _safetensors_lora()[:-8]
+        with self.assertRaisesRegex(RuntimeError, "truncated|offsets"):
+            P.import_h3_lora_file("truncated.safetensors", header_only)
+
+        self.assertEqual(list(self.dir.iterdir()), [])
+
+    def test_refuses_duplicate_name_without_replacing_first_import(self):
+        first = _safetensors_lora()
+        replacement = _safetensors_lora(alpha=1.0)
+        P.import_h3_lora_file("keep-me.safetensors", first)
+
+        with self.assertRaises(FileExistsError):
+            P.import_h3_lora_file("keep-me.safetensors", replacement)
+
+        self.assertEqual((self.dir / "keep-me.safetensors").read_bytes(), first)
+
+    def test_picker_markup_has_a_real_import_control(self):
+        panel = (ROOT / "mlx_ltx_panel.py").read_text(encoding="utf-8")
+        self.assertIn("Import H3 LoRA", panel)
+        self.assertIn("/h3/loras/import", panel)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test_h3_lora_file_import.py
+++ b/test_h3_lora_file_import.py
@@ -20,7 +20,8 @@ import mlx_ltx_panel as P
 
 
 def _safetensors_lora(*, alpha: float | None = None,
-                      module: str = "blocks.24.attn.qkv_proj") -> bytes:
+                      module: str = "blocks.24.attn.qkv_proj",
+                      metadata: dict | None = None) -> bytes:
     """A tiny but complete F32 A/B safetensors payload for import validation."""
     names = (
         module + ".lora_A.weight",
@@ -29,7 +30,7 @@ def _safetensors_lora(*, alpha: float | None = None,
     values = [(name, struct.pack("<f", 0.0)) for name in names]
     if alpha is not None:
         values.append((module + ".alpha", struct.pack("<f", alpha)))
-    header = {}
+    header = {"__metadata__": metadata} if metadata is not None else {}
     offset = 0
     for key, raw in values:
         header[key] = {"dtype": "F32",
@@ -88,6 +89,13 @@ class TestH3LoraFileImport(unittest.TestCase):
             P.import_h3_lora_file("needs-scale.safetensors", _safetensors_lora(alpha=8.0))
 
         self.assertEqual(list(self.dir.iterdir()), [])
+
+    def test_imports_explicit_scale_one_conversion_metadata(self):
+        result = P.import_h3_lora_file(
+            "converted.safetensors",
+            _safetensors_lora(metadata={"alpha": "alpha == rank; scale = 1.0"}))
+
+        self.assertEqual(result["filename"], "converted.safetensors")
 
     def test_refuses_unreadable_alpha_without_leaving_a_file(self):
         payload = _safetensors_lora(alpha=1.0)[:-4]

--- a/test_h3_lora_manual_import.py
+++ b/test_h3_lora_manual_import.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Regression gates for the documented manual H3 LoRA import flow."""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+class TestH3ManualLoraImportCopy(unittest.TestCase):
+    def test_h3_empty_state_names_manual_drop_directory_and_key_layout(self):
+        """The H3 picker must explain the no-CivitAI manual import route."""
+        panel = (ROOT / "mlx_ltx_panel.py").read_text(encoding="utf-8")
+        self.assertIn("Drop a converted H3 <code>.safetensors</code>", panel)
+        self.assertIn("<code>lora_A</code> / <code>lora_B</code>", panel)
+        self.assertIn("the <strong>Hailuo H3</strong> CivitAI filter", panel)
+
+    def test_readme_documents_h3_library_separately_from_ltx(self):
+        """A user following the public manual cannot put an H3 LoRA in LTX's tree."""
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("`mlx_models/hailuo-h3/loras/`", readme)
+        self.assertIn("`lora_A` / `lora_B`", readme)
+        self.assertIn("Kohya", readme)
+        self.assertIn("**My LoRA**", readme)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Add an **Import H3 LoRA** file picker to the Hailuo H3 LoRAs panel.
- Import valid H3 `.safetensors` adapters into H3’s separate LoRA library.
- Validate adapter A/B tensor layout, tensor payload bounds, ranks, alpha/rank strength, and target modules against the installed H3 transformer.
- Reject raw Kohya-format files, malformed/truncated files, non-unit alpha/rank adapters, duplicate names, and adapters that would not affect the installed H3 model.
- Keep Turbo and custom H3 LoRAs mutually exclusive because the H3 runner supports one adapter slot per render.

## Validation

- `test_h3_lora_file_import`, `test_h3_turbo_adapter`, and `test_h3_lora_manual_import`: **22 passed**
- Full repository test discovery: **passed**