### PR TITLE
fix: restore inline onclick handlers broken by the module split

### DIFF
--- a/webapp/js/characters.js
+++ b/webapp/js/characters.js
@@ -2825,3 +2825,22 @@ Object.assign(globalThis, {
   setUpscale, setUpscaleMethod, updateAccelAvailability, updateTemporalAvailability,
   setAspect, updateCustomizeSummary, updatePromptPlaceholder,
 });
+
+// --- expose inline event-handler functions to window --------------------
+// index.html's dynamically-generated markup (candidate cards, modals, etc.)
+// wires up interactivity with plain onclick="fn(...)" attribute strings.
+// Since this file now runs as <script type="module"> (v4.9.0 restructuring),
+// top-level `function`/`const` bindings are scoped to the module and are no
+// longer visible as globals, so every such inline handler threw
+// "fn is not defined" in the console and silently did nothing when clicked.
+// Re-exporting the handlers actually referenced by inline attributes here
+// restores click wiring without rewriting every template string to use
+// addEventListener/delegation.
+Object.assign(window, {
+  audioStudioClearAudio,
+  charactersOpenCompose,
+  charactersPickChip,
+  trainInstall,
+  trainRemoveImage,
+  trainUseInVideo
+});

--- a/webapp/js/editor.js
+++ b/webapp/js/editor.js
@@ -7915,3 +7915,36 @@ Object.assign(globalThis, {
   sbeAuto, sbeGenClose, sbeGenSubmit, sbeRenderFilm,
   sbeExportNle, sbeTick, workflowSwitch,
 });
+
+// --- expose inline event-handler functions to window --------------------
+// index.html's dynamically-generated markup (candidate cards, modals, etc.)
+// wires up interactivity with plain onclick="fn(...)" attribute strings.
+// Since this file now runs as <script type="module"> (v4.9.0 restructuring),
+// top-level `function`/`const` bindings are scoped to the module and are no
+// longer visible as globals, so every such inline handler threw
+// "fn is not defined" in the console and silently did nothing when clicked.
+// Re-exporting the handlers actually referenced by inline attributes here
+// restores click wiring without rewriting every template string to use
+// addEventListener/delegation.
+Object.assign(window, {
+  edOpenBoard,
+  edPoolAdd,
+  edPoolOverlay,
+  edPoolPreview,
+  sbeAddPointAtPlayhead,
+  sbeAudioFadeCommit,
+  sbeBrightCommit,
+  sbeBrightPreview,
+  sbeClearPoints,
+  sbeDeleteStripSel,
+  sbeErrsToggle,
+  sbeFadeCommit,
+  sbeOvDeleteSel,
+  sbeOvFadeCommit,
+  sbePlace,
+  sbeResyncSel,
+  sbeRippleSelected,
+  sbeToggleAudioLink,
+  sbeToggleClipMute,
+  sbeToggleLock
+});

--- a/webapp/js/loras.js
+++ b/webapp/js/loras.js
@@ -1260,3 +1260,24 @@ Object.assign(globalThis, {
   renderLorasList, appendTriggerToPrompt, _updateCharsPickerVisibility, refreshManualCharacters,
   _renderManualCharactersList, _renderCharsAppliedNote, renderCharacterStrip,
 });
+
+// --- expose inline event-handler functions to window --------------------
+// index.html's dynamically-generated markup (candidate cards, modals, etc.)
+// wires up interactivity with plain onclick="fn(...)" attribute strings.
+// Since this file now runs as <script type="module"> (v4.9.0 restructuring),
+// top-level `function`/`const` bindings are scoped to the module and are no
+// longer visible as globals, so every such inline handler threw
+// "fn is not defined" in the console and silently did nothing when clicked.
+// Re-exporting the handlers actually referenced by inline attributes here
+// restores click wiring without rewriting every template string to use
+// addEventListener/delegation.
+Object.assign(window, {
+  appendTriggerToPrompt,
+  deleteLora,
+  downloadLora,
+  removeLoraFromActive,
+  renameLora,
+  renderLorasList,
+  setLoraStrength,
+  toggleLora
+});

--- a/webapp/js/preview.js
+++ b/webapp/js/preview.js
@@ -1808,3 +1808,24 @@ Object.assign(globalThis, {
   openModelsModal, closeModelsModal, refreshModelsModal, startDownload,
   cancelDownload,
 });
+
+// --- expose inline event-handler functions to window --------------------
+// index.html's dynamically-generated markup (candidate cards, modals, etc.)
+// wires up interactivity with plain onclick="fn(...)" attribute strings.
+// Since this file now runs as <script type="module"> (v4.9.0 restructuring),
+// top-level `function`/`const` bindings are scoped to the module and are no
+// longer visible as globals, so every such inline handler threw
+// "fn is not defined" in the console and silently did nothing when clicked.
+// Re-exporting the handlers actually referenced by inline attributes here
+// restores click wiring without rewriting every template string to use
+// addEventListener/delegation.
+Object.assign(window, {
+  _charactersManageDelete,
+  _charactersManageSave,
+  cancelDownload,
+  civitaiAuthSave,
+  civitaiSetFamily,
+  closeCharactersManageModal,
+  renderCivitaiAuthBanner,
+  startDownload
+});

--- a/webapp/js/queue.js
+++ b/webapp/js/queue.js
@@ -4410,3 +4410,28 @@ Object.assign(globalThis, {
   useAsExtendSource, loadParams, _flashActionDone, closeOutputInfoModal,
   togglePause, openBatch, closeBatch, queueBatch,
 });
+
+// --- expose inline event-handler functions to window --------------------
+// index.html's dynamically-generated markup (candidate cards, modals, etc.)
+// wires up interactivity with plain onclick="fn(...)" attribute strings.
+// Since this file now runs as <script type="module"> (v4.9.0 restructuring),
+// top-level `function`/`const` bindings are scoped to the module and are no
+// longer visible as globals, so every such inline handler threw
+// "fn is not defined" in the console and silently did nothing when clicked.
+// Re-exporting the handlers actually referenced by inline attributes here
+// restores click wiring without rewriting every template string to use
+// addEventListener/delegation.
+Object.assign(window, {
+  _copyToClipboard,
+  animateFromPhoto,
+  closeOutputInfoModal,
+  deleteOutput,
+  loadParams,
+  openOutputInfoModal,
+  remakeInQuality,
+  removeJob,
+  renderCarousel,
+  repairModel,
+  retryJob,
+  selectOutput
+});

--- a/webapp/js/settings.js
+++ b/webapp/js/settings.js
@@ -1198,3 +1198,17 @@ Object.assign(globalThis, {
   toggleSpicyMode, onTokenInput, toggleTokenVisibility, testToken,
   clearToken, closeSettingsModal, applySettings, _applyHdrPillAvailability,
 });
+
+// --- expose inline event-handler functions to window --------------------
+// index.html's dynamically-generated markup (candidate cards, modals, etc.)
+// wires up interactivity with plain onclick="fn(...)" attribute strings.
+// Since this file now runs as <script type="module"> (v4.9.0 restructuring),
+// top-level `function`/`const` bindings are scoped to the module and are no
+// longer visible as globals, so every such inline handler threw
+// "fn is not defined" in the console and silently did nothing when clicked.
+// Re-exporting the handlers actually referenced by inline attributes here
+// restores click wiring without rewriting every template string to use
+// addEventListener/delegation.
+Object.assign(window, {
+  removeStoragePack
+});

--- a/webapp/js/stage.js
+++ b/webapp/js/stage.js
@@ -1837,3 +1837,18 @@ Object.assign(globalThis, {
   ideoBuildCaption, ideoOnRawInput, ideoApplyRaw, ideoLoadExample,
   ideoStagePointerDown, imgStudioGenerate, imgStudioRefreshLibrary, imgStudioCopyPath,
 });
+
+// --- expose inline event-handler functions to window --------------------
+// index.html's dynamically-generated markup (candidate cards, modals, etc.)
+// wires up interactivity with plain onclick="fn(...)" attribute strings.
+// Since this file now runs as <script type="module"> (v4.9.0 restructuring),
+// top-level `function`/`const` bindings are scoped to the module and are no
+// longer visible as globals, so every such inline handler threw
+// "fn is not defined" in the console and silently did nothing when clicked.
+// Re-exporting the handlers actually referenced by inline attributes here
+// restores click wiring without rewriting every template string to use
+// addEventListener/delegation.
+Object.assign(window, {
+  imgStudioClearRef,
+  openExternal
+});

--- a/webapp/js/storyboard.js
+++ b/webapp/js/storyboard.js
@@ -2112,3 +2112,26 @@ Object.assign(globalThis, {
   sbFilmPaint, sbBoardChip, sbRowAction, sbAddActiveToBoard,
   sbOpenFromClip, sbPollHook,
 });
+
+// --- expose inline event-handler functions to window --------------------
+// index.html's dynamically-generated markup (candidate cards, modals, etc.)
+// wires up interactivity with plain onclick="fn(...)" attribute strings.
+// Since this file now runs as <script type="module"> (v4.9.0 restructuring),
+// top-level `function`/`const` bindings are scoped to the module and are no
+// longer visible as globals, so every such inline handler threw
+// "fn is not defined" in the console and silently did nothing when clicked.
+// Re-exporting the handlers actually referenced by inline attributes here
+// restores click wiring without rewriting every template string to use
+// addEventListener/delegation.
+Object.assign(window, {
+  sbDeleteBoard,
+  sbFilmReveal,
+  sbFilmSelect,
+  sbFixError,
+  sbGo,
+  sbOpen,
+  sbOpenAt,
+  sbOpenShotClip,
+  sbPickCast,
+  sbScrollToShot
+});


### PR DESCRIPTION
v4.9.0's restructuring moved webapp/js/*.js to <script type="module">. These files declare their handler functions as plain top-level function/const bindings and never use import/export between them, so under module scoping those bindings are private to each file and no longer land on window.

The dynamically-generated markup (candidate cards, modals, timeline controls, etc.) still wires up interactivity the old way, with plain onclick="fn(...)" attribute strings baked into template literals. Those strings resolve against the global scope, so after the module split every such handler threw "fn is not defined" in the console and silently did nothing when clicked - reported as "these buttons on the image do nothing" for the candidate card's Quality/Animate/delete row, but it affects 67 handler functions across 8 files (queue, characters, editor, loras, preview, settings, stage, storyboard) - LoRA management, character training, timeline editing, and Civitai downloads were all silently dead too.

Fix: append an explicit Object.assign(window, {...}) re-export block to each affected file, listing only the handlers actually referenced by inline attributes in that file's generated markup. Matches the existing precedent of exposing cross-file state via window/globalThis (window.CHARACTERS, window.SBE, window.setTrainType, etc.) rather than rewriting every template string to use addEventListener/delegation.

Purely additive - 171 insertions, 0 deletions, no existing line touched.